### PR TITLE
Handle recurring tasks when rescheduling

### DIFF
--- a/app/models/todoist/api/tasks.rb
+++ b/app/models/todoist/api/tasks.rb
@@ -6,8 +6,10 @@ module Todoist
       Task = Data.define(
         :assignee_id,
         :assigner_id,
-        :content, :creator_id,
+        :content,
+        :creator_id,
         :description,
+        :due,
         :id,
         :is_completed,
         :priority,
@@ -15,6 +17,12 @@ module Todoist
       ) do
         def update(...) = Todoist::Api::Tasks.update(id, ...)
       end
+
+      Due = Data.define(
+        :date,
+        :string,
+        :is_recurring
+      )
 
       # https://developer.todoist.com/rest/v2/#get-active-tasks
       def self.rollable
@@ -44,7 +52,12 @@ module Todoist
           id: json["id"],
           is_completed: json["is_completed"],
           priority: json["priority"],
-          project_id: json["project_id"]
+          project_id: json["project_id"],
+          due: Due.new(
+            date: Date.parse(json.dig("due", "date")),
+            string: json.dig("due", "string"),
+            is_recurring: json.dig("due", "is_recurring")
+          )
         )
       end
     end

--- a/app/models/todoist/reschedule_rollable_tasks.rb
+++ b/app/models/todoist/reschedule_rollable_tasks.rb
@@ -7,7 +7,7 @@ module Todoist
     end
 
     def perform
-      tasks.each { rescheule_task(_1) }
+      tasks.map { rescheule_task(_1) }
     end
 
     private
@@ -15,7 +15,12 @@ module Todoist
     attr_reader :tasks
 
     def rescheule_task(task)
-      task.update({"due_string" => "tomorrow"})
+      tomorrow = (task.due.date + 1.day).iso8601
+
+      task.update({
+        "due_string" => task.due.string,
+        "due_date" => tomorrow
+      })
     end
   end
 end

--- a/spec/factories/todoist_api_task_factory.rb
+++ b/spec/factories/todoist_api_task_factory.rb
@@ -12,5 +12,23 @@ FactoryBot.define do
     is_completed { false }
     priority { 1 }
     project_id { "123" }
+    due do
+      Todoist::Api::Tasks::Due.new(
+        date: due_date,
+        string: due_string,
+        is_recurring: due_is_recurring
+      )
+    end
+
+    transient do
+      due_date { Date.current }
+      due_string { "today" }
+      due_is_recurring { false }
+    end
+
+    trait :recurring do
+      due_string { "every! 3 days" }
+      due_is_recurring { true }
+    end
   end
 end

--- a/spec/models/todoist/api/tasks_spec.rb
+++ b/spec/models/todoist/api/tasks_spec.rb
@@ -12,7 +12,12 @@ RSpec.describe Todoist::Api::Tasks do
         "id" => "123",
         "is_completed" => "123",
         "priority" => "123",
-        "project_id" => "123"
+        "project_id" => "123",
+        "due" => {
+          "date" => "2024-08-26",
+          "is_recurring" => false,
+          "string" => "tomorrow"
+        }
       }
 
       result = described_class.from_json(json)
@@ -26,7 +31,12 @@ RSpec.describe Todoist::Api::Tasks do
         id: "123",
         is_completed: "123",
         priority: "123",
-        project_id: "123"
+        project_id: "123",
+        due: described_class::Due.new(
+          date: Date.parse("2024-08-26"),
+          is_recurring: false,
+          string: "tomorrow"
+        )
       ))
     end
   end

--- a/spec/models/todoist/reschedule_rollable_tasks_spec.rb
+++ b/spec/models/todoist/reschedule_rollable_tasks_spec.rb
@@ -15,4 +15,21 @@ RSpec.describe Todoist::RescheduleRollableTasks, ".perform" do
 
     expect(update_mock).to have_been_requested
   end
+
+  it "reschedules a recurring task" do
+    task = build(:todoist_api_task, :recurring)
+    TodoistApiMocks.mock_tasks_rollable([task])
+    update_mock = TodoistApiMocks.mock_task_update(
+      task,
+      result: task
+    ).with do |req|
+      body = JSON.parse(req.body)
+      expect(body["due_string"]).to eql(task.due.string)
+      expect(body["due_date"]).to eql((task.due.date + 1.day).iso8601)
+    end
+
+    described_class.perform
+
+    expect(update_mock).to have_been_requested
+  end
 end

--- a/spec/support/todoist_api_mocks.rb
+++ b/spec/support/todoist_api_mocks.rb
@@ -11,13 +11,12 @@ module TodoistApiMocks
   end
 
   def self.mock_task_update(task, result:)
-    WebMock::API.stub_request(
-      :post,
-      "https://api.todoist.com/rest/v2/tasks/#{task.id}"
-    ).to_return(
-      status: 200,
-      body: result.to_json,
-      headers: {"content-type" => "application/json"}
-    )
+    WebMock::API
+      .stub_request(:post, "https://api.todoist.com/rest/v2/tasks/#{task.id}")
+      .to_return(
+        status: 200,
+        body: result.to_json,
+        headers: {"content-type" => "application/json"}
+      )
   end
 end


### PR DESCRIPTION
Recurring tasks already have a due string present so I don't want to overwrite it by always setting it to "tomorrow". Instead we can update the due_date field while preserving the due_string field. This seems to update the due date while preserving the recurring date.