### PR TITLE
Upgrade kamal from 1.8 to 1.9

### DIFF
--- a/kamal/Gemfile
+++ b/kamal/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "kamal", "~> 1.8.0"
+gem "kamal", "~> 1.9.0"

--- a/kamal/Gemfile.lock
+++ b/kamal/Gemfile.lock
@@ -22,9 +22,9 @@ GEM
     dotenv (2.8.1)
     drb (2.2.1)
     ed25519 (1.3.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    kamal (1.8.3)
+    kamal (1.9.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
@@ -61,7 +61,7 @@ PLATFORMS
   x86_64-darwin
 
 DEPENDENCIES
-  kamal (~> 1.8.0)
+  kamal (~> 1.9.0)
 
 BUNDLED WITH
    2.5.18


### PR DESCRIPTION
This is part of upgrading to kamal 2.0. It's recommended to first upgrade to 1.9, since that version has the capability to rollback the 2.0 upgrade if something goes wrong.