### PR TITLE
Fix migrations path

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,6 +19,7 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   url: <%= Rails.application.credentials.dig(:db, :url) %>
+  migrations_paths: ["db/migrate"]
 
 queue_default: &queue_default
   adapter: postgresql
@@ -27,14 +28,13 @@ queue_default: &queue_default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   url: <%= Rails.application.credentials.dig(:db, :queue_url) %>
+  migrations_paths: ["db/queue_migrate"]
 
 development:
   primary:
     <<: *default
-    migrations_path: db/migrate
   queue:
     <<: *queue_default
-    migrations_path: db/queue_migrate
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.

--- a/config/database.yml
+++ b/config/database.yml
@@ -31,8 +31,10 @@ queue_default: &queue_default
 development:
   primary:
     <<: *default
+    migrations_path: db/migrate
   queue:
     <<: *queue_default
+    migrations_path: db/queue_migrate
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.

--- a/db/queue_migrate/20240825153541_create_solid_queue_tables.solid_queue.rb
+++ b/db/queue_migrate/20240825153541_create_solid_queue_tables.solid_queue.rb
@@ -1,0 +1,101 @@
+# This migration comes from solid_queue (originally 20231211200639)
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
+  def change
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false, index: true
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id, index: true
+      t.datetime :scheduled_at
+      t.datetime :finished_at, index: true
+      t.string :concurrency_key
+
+      t.timestamps
+
+      t.index [:queue_name, :finished_at], name: "index_solid_queue_jobs_for_filtering"
+      t.index [:scheduled_at, :finished_at], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:scheduled_at, :priority, :job_id], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:priority, :job_id], name: "index_solid_queue_poll_all"
+      t.index [:queue_name, :priority, :job_id], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+
+      t.index [:process_id, :job_id]
+    end
+
+    create_table :solid_queue_blocked_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:expires_at, :concurrency_key], name: "index_solid_queue_blocked_executions_for_maintenance"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false, index: {unique: true}
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false, index: true
+      t.bigint :supervisor_id, index: true
+
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+
+      t.datetime :created_at, null: false
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false, index: true
+
+      t.timestamps
+
+      t.index [:key, :value], name: "index_solid_queue_semaphores_on_key_and_value"
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/queue_migrate/20240825153542_add_missing_index_to_blocked_executions.solid_queue.rb
+++ b/db/queue_migrate/20240825153542_add_missing_index_to_blocked_executions.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240110143450)
+class AddMissingIndexToBlockedExecutions < ActiveRecord::Migration[7.1]
+  def change
+    add_index :solid_queue_blocked_executions, [:concurrency_key, :priority, :job_id], name: "index_solid_queue_blocked_executions_for_release"
+  end
+end

--- a/db/queue_migrate/20240825153543_create_recurring_executions.solid_queue.rb
+++ b/db/queue_migrate/20240825153543_create_recurring_executions.solid_queue.rb
@@ -1,0 +1,15 @@
+# This migration comes from solid_queue (originally 20240218110712)
+class CreateRecurringExecutions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_executions do |t|
+      t.references :job, index: {unique: true}, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+
+      t.index [:task_key, :run_at], unique: true
+    end
+
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end

--- a/db/queue_migrate/20240825153544_create_recurring_tasks.solid_queue.rb
+++ b/db/queue_migrate/20240825153544_create_recurring_tasks.solid_queue.rb
@@ -1,0 +1,21 @@
+# This migration comes from solid_queue (originally 20240719134516)
+class CreateRecurringTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false, index: {unique: true}
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+
+      t.string :queue_name
+      t.integer :priority, default: 0
+
+      t.boolean :static, default: true, index: true
+
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/queue_migrate/20240825153545_add_name_to_processes.solid_queue.rb
+++ b/db/queue_migrate/20240825153545_add_name_to_processes.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240811173327)
+class AddNameToProcesses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :solid_queue_processes, :name, :string
+  end
+end

--- a/db/queue_migrate/20240825153546_make_name_not_null.solid_queue.rb
+++ b/db/queue_migrate/20240825153546_make_name_not_null.solid_queue.rb
@@ -1,0 +1,17 @@
+# This migration comes from solid_queue (originally 20240813160053)
+class MakeNameNotNull < ActiveRecord::Migration[7.1]
+  def up
+    SolidQueue::Process.where(name: nil).find_each do |process|
+      process.name ||= [process.kind.downcase, SecureRandom.hex(10)].join("-")
+      process.save!
+    end
+
+    change_column :solid_queue_processes, :name, :string, null: false
+    add_index :solid_queue_processes, [:name, :supervisor_id], unique: true
+  end
+
+  def down
+    remove_index :solid_queue_processes, [:name, :supervisor_id]
+    change_column :solid_queue_processes, :name, :string, null: false
+  end
+end

--- a/db/queue_migrate/20240825153547_change_solid_queue_recurring_tasks_static_to_not_null.solid_queue.rb
+++ b/db/queue_migrate/20240825153547_change_solid_queue_recurring_tasks_static_to_not_null.solid_queue.rb
@@ -1,0 +1,6 @@
+# This migration comes from solid_queue (originally 20240819165045)
+class ChangeSolidQueueRecurringTasksStaticToNotNull < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :solid_queue_recurring_tasks, :static, false, true
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,6 +1,21 @@
-ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2024_08_25_153547) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.string "concurrency_key", null: false
@@ -12,7 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
   end
 
   create_table "solid_queue_claimed_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.bigint "process_id"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
@@ -20,7 +35,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
   end
 
   create_table "solid_queue_failed_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.text "error"
     t.datetime "created_at", null: false
     t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
@@ -65,7 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
   end
 
   create_table "solid_queue_ready_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "created_at", null: false
@@ -75,7 +90,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
   end
 
   create_table "solid_queue_recurring_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.string "task_key", null: false
     t.datetime "run_at", null: false
     t.datetime "created_at", null: false
@@ -100,7 +115,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
   end
 
   create_table "solid_queue_scheduled_executions", force: :cascade do |t|
-    t.integer "job_id", null: false
+    t.bigint "job_id", null: false
     t.string "queue_name", null: false
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at", null: false
@@ -118,6 +133,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_04_193154) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", null: false
+    t.string "foreign_id", null: false
+    t.string "access_token", null: false
+    t.string "refresh_token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["foreign_id"], name: "index_users_on_foreign_id", unique: true
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -135,17 +135,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_25_153547) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "email", null: false
-    t.string "foreign_id", null: false
-    t.string "access_token", null: false
-    t.string "refresh_token", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["foreign_id"], name: "index_users_on_foreign_id", unique: true
-  end
-
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade


### PR DESCRIPTION
When I added a separate db for queues I didn't quite do all of the necessary work to correctly setup a second database. In particular I didn't separate the migrations, so when I went to add a new migration it migrated both databases, which is not what I wanted.

Now the migrations are separate and you can make changes to one db without affecting the other. This is how it should have been from the beginning.