### PR TITLE
Use op cli for kamal secrets

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,3 +1,3 @@
-KAMAL_REGISTRY_USERNAME=$KAMAL_REGISTRY_USERNAME
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-RAILS_MASTER_KEY=$RAILS_MASTER_KEY
+KAMAL_REGISTRY_USERNAME=$(op item get "Docker" --account="my.1password.com" --vault="Private" --fields="CLI username" --reveal)
+KAMAL_REGISTRY_PASSWORD=$(op item get "Docker" --account="my.1password.com" --vault="Private" --fields=password --reveal)
+RAILS_MASTER_KEY=$(op item get "credentials/production.key" --account="my.1password.com" --vault="Homepage" --fields=password --reveal)


### PR DESCRIPTION
I had been exporting them but with kamal 2 it's a bit easier.

I didn't want to use kamal's built in 1p secret adapter because I know how to use `op` and I figure that's less likely to change over time.