### PR TITLE
Revert "Use op cli for kamal secrets"

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,3 +1,3 @@
-KAMAL_REGISTRY_USERNAME=$(op item get "Docker" --account="my.1password.com" --vault="Private" --fields="CLI username" --reveal)
-KAMAL_REGISTRY_PASSWORD=$(op item get "Docker" --account="my.1password.com" --vault="Private" --fields=password --reveal)
-RAILS_MASTER_KEY=$(op item get "credentials/production.key" --account="my.1password.com" --vault="Homepage" --fields=password --reveal)
+KAMAL_REGISTRY_USERNAME=$KAMAL_REGISTRY_USERNAME
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+RAILS_MASTER_KEY=$RAILS_MASTER_KEY


### PR DESCRIPTION
Reverts jutonz/homepage-rb#96

this works locally but not on CI, where `op` is not installed. I don't want to install it there so for now just going back to using env vars. This is fine but just clunky locally. 