### PR TITLE
Reschedule overdue tasks hourly

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,3 +1,3 @@
 reschedule_rollable_tasks:
   class: "Todoist::RescheduleRollableTasksJob"
-  schedule: "0 2 * * *"
+  schedule: "0 * * * *"


### PR DESCRIPTION
Rather than just once per day, run this task hourly. This way any adjustments to due dates throughout the day will be updated a bit sooner.