### PR TITLE
Don't roll tasks due today

### DIFF
--- a/app/models/todoist/api/tasks.rb
+++ b/app/models/todoist/api/tasks.rb
@@ -56,7 +56,7 @@ module Todoist
 
       # https://developer.todoist.com/rest/v2/#get-active-tasks
       def self.rollable
-        params = {"filter" => "@rollable,today | overdue"}
+        params = {"filter" => "@rollable,overdue"}
 
         Todoist::Api::Client
           .get("/rest/v2/tasks", params)

--- a/spec/support/todoist_api_mocks.rb
+++ b/spec/support/todoist_api_mocks.rb
@@ -24,7 +24,7 @@ module TodoistApiMocks
   def self.mock_tasks_rollable(tasks)
     WebMock::API.stub_request(
       :get,
-      "https://api.todoist.com/rest/v2/tasks?filter=@rollable,today | overdue"
+      "https://api.todoist.com/rest/v2/tasks?filter=@rollable,overdue"
     ).to_return(
       status: 200,
       body: Array(tasks).to_json,


### PR DESCRIPTION
Wait until they are overdue until rolling over to the next day. Including tasks due today made sense when this job was run near the end of the day, since at that point it was unlikely that the tasks would be completed anyway. But now that this job runs hourly, we don't want to roll over tasks until they're actually overdue.

This will fix an issue where rollable tasks were always pushed to to the next day.