### PR TITLE
Retry rollable tasks job on error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.1)
+    brakeman (6.2.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/app/jobs/todoist/reschedule_rollable_tasks_job.rb
+++ b/app/jobs/todoist/reschedule_rollable_tasks_job.rb
@@ -2,6 +2,8 @@ module Todoist
   class RescheduleRollableTasksJob < ApplicationJob
     queue_as :background
 
+    retry_on Faraday::ServerError
+
     def perform
       Todoist::RescheduleRollableTasks.perform
     end

--- a/spec/jobs/todoist/reschedule_rollable_tasks_job_spec.rb
+++ b/spec/jobs/todoist/reschedule_rollable_tasks_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Todoist::RescheduleRollableTasksJob do
+  include ActiveJob::TestHelper
+
+  it "reschedules jobs" do
+    allow(Todoist::RescheduleRollableTasks).to receive(:perform)
+
+    described_class.new.perform
+
+    expect(Todoist::RescheduleRollableTasks).to have_received(:perform)
+  end
+
+  it "retries if a server error occurs" do
+    allow(Todoist::RescheduleRollableTasks)
+      .to receive(:perform)
+      .and_raise(Faraday::ServerError)
+
+    perform_enqueued_jobs do
+      described_class.perform_now
+    rescue Faraday::ServerError
+      nil # perform_enqueued_jobs will complain if an exception is raised
+    end
+
+    expect(Todoist::RescheduleRollableTasks)
+      .to have_received(:perform)
+      .exactly(5).times
+  end
+end


### PR DESCRIPTION
Looks like todoist frequently returns an API error. Here I'll retry up to 5 times. This should also prevent the error from making its way to Sentry in most cases.