### PR TITLE
Automerge some dependencies

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,3 @@
+- match:
+    dependency_name: "aws-sdk-v3"
+    update_type: semver:minor

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,14 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
Reduce maintenance burden a bit by automatically merging some dependency updates. There's an allowlist saying which can be merged. This only applies to PR's opened by dependabot.