### PR TITLE
Ignore trailing whitespace in tag search

### DIFF
--- a/app/models/galleries/images/tag_search.rb
+++ b/app/models/galleries/images/tag_search.rb
@@ -7,28 +7,12 @@ module Galleries
       attr_accessor :image
       attr_accessor :query
 
-      # validates :name, presence: true
-      #
-      # def save
-      #   return false unless valid?
-
-      # ActiveRecord::Base.transaction do
-      #   files.each do |file|
-      #     next if file.blank?
-      #     gallery.images.create!(file:)
-      #   end
-      # end
-
-      #   true
-      # end
-      #
-
       def results
         return Tag.none if query.nil?
 
         gallery
           .tags
-          .where("galleries_tags.name ILIKE ?", "%#{query}%")
+          .where("galleries_tags.name ILIKE ?", "%#{query.strip}%")
           .where.not(id: image.tags.select(:id))
       end
     end

--- a/app/models/galleries/tag.rb
+++ b/app/models/galleries/tag.rb
@@ -33,13 +33,5 @@ module Galleries
     validates :name,
       presence: true,
       uniqueness: {scope: :gallery_id}
-
-    def self.search(term, image:)
-      if term.blank?
-        all
-      else
-        where("name ILIKE ?", "%#{term}%")
-      end
-    end
   end
 end

--- a/spec/factories/galleries/images/tag_searches.rb
+++ b/spec/factories/galleries/images/tag_searches.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :galleries_images_tag_search, class: "Galleries::Images::TagSearch" do
+    skip_create
+
+    image factory: :galleries_image
+    gallery { instance.image.gallery }
+  end
+end

--- a/spec/models/galleries/images/tag_search_spec.rb
+++ b/spec/models/galleries/images/tag_search_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe Galleries::Images::TagSearch do
+  describe "#results" do
+    it "returns nothing if the query is nil" do
+      search = build(
+        :galleries_images_tag_search,
+        query: nil
+      )
+
+      expect(search.results).to be_blank
+    end
+
+    it "returns tags matching the name" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+      matching_tag = create(:galleries_tag, gallery:, name: "hello")
+      _not_matching_tag = create(:galleries_tag, gallery:, name: "goodbye")
+      search = build(
+        :galleries_images_tag_search,
+        gallery:,
+        image:,
+        query: "hello"
+      )
+
+      result = search.results.pluck(:id)
+
+      expect(result).to eql([matching_tag.id])
+    end
+
+    it "supports partial matches" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:, name: "hello")
+      search = build(
+        :galleries_images_tag_search,
+        gallery:,
+        image:,
+        query: "hel"
+      )
+
+      result = search.results.pluck(:id)
+
+      expect(result).to eql([tag.id])
+    end
+
+    it "ignores trailing whitespace in the query" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:, name: "hello")
+      search = build(
+        :galleries_images_tag_search,
+        gallery:,
+        image:,
+        query: "hello "
+      )
+
+      result = search.results.pluck(:id)
+
+      expect(result).to eql([tag.id])
+    end
+
+    it "doesn't return tags belonging to other galleries" do
+      search = build(:galleries_images_tag_search, query: "hello")
+      gallery = search.gallery
+      tag = create(:galleries_tag, gallery:, name: "hello")
+      _other_tag = create(:galleries_tag, name: "hello")
+
+      result = search.results.pluck(:id)
+
+      expect(result).to eql([tag.id])
+    end
+
+    it "excludes tags already applied to the image" do
+      search = build(:galleries_images_tag_search, query: "hello")
+      gallery = search.gallery
+      image = search.image
+      tag = create(:galleries_tag, gallery:, name: "hello")
+      image.add_tag(tag)
+
+      result = search.results.pluck(:id)
+
+      expect(result).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
ios will automatically add whitespace to the end of an autocompleted word. This results in searches not matching, because you're searching for a string `"hello "` when the tag's name is just `"hello"`. Here I update the search logic to ignore trailing whitespace.