### PR TITLE
Rework recently used tags

### DIFF
--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -33,12 +33,20 @@ class Gallery < ActiveRecord::Base
 
   def self.hidden = where.not(hidden_at: nil)
 
-  def recently_used_tags
-    tags
-      .joins(:image_tags)
-      .order(galleries_image_tags: {created_at: :desc})
-      .limit(100)
-      .uniq
-      .take(10)
+  def recently_used_tags(image_limit: 4)
+    recently_tagged_image_ids =
+      images
+        .joins(:image_tags)
+        .order(galleries_image_tags: {created_at: :desc})
+        .limit(image_limit)
+        .select(:id)
+
+    tag_ids =
+      tags
+        .joins(:images)
+        .where(galleries_images: {id: recently_tagged_image_ids})
+        .distinct
+
+    tags.where(id: tag_ids).order(:name).tap { puts _1.to_sql }
   end
 end


### PR DESCRIPTION
Instead of ordering tags by recently used, display all the tags that were added to the last 5 images which had tags applied. Frequently images imported in sequence will have many of the same tags, so this shoudl make applying those much easier.