### PR TITLE
Display tags count

### DIFF
--- a/app/models/galleries/image_tag.rb
+++ b/app/models/galleries/image_tag.rb
@@ -22,7 +22,9 @@
 module Galleries
   class ImageTag < ApplicationRecord
     belongs_to :image, class_name: "Galleries::Image"
-    belongs_to :tag, class_name: "Galleries::Tag"
+    belongs_to :tag,
+      class_name: "Galleries::Tag",
+      counter_cache: :image_tags_count
 
     validates :tag, uniqueness: {scope: :image_id}
   end

--- a/app/models/galleries/tag.rb
+++ b/app/models/galleries/tag.rb
@@ -2,12 +2,13 @@
 #
 # Table name: galleries_tags
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  gallery_id :bigint           not null
-#  user_id    :bigint           not null
+#  id               :bigint           not null, primary key
+#  image_tags_count :integer          default(0), not null
+#  name             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  gallery_id       :bigint           not null
+#  user_id          :bigint           not null
 #
 # Indexes
 #
@@ -33,5 +34,9 @@ module Galleries
     validates :name,
       presence: true,
       uniqueness: {scope: :gallery_id}
+
+    def display_name
+      "#{name} (#{image_tags.size})"
+    end
   end
 end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -47,6 +47,6 @@ class Gallery < ActiveRecord::Base
         .where(galleries_images: {id: recently_tagged_image_ids})
         .distinct
 
-    tags.where(id: tag_ids).order(:name).tap { puts _1.to_sql }
+    tags.where(id: tag_ids).order(:name)
   end
 end

--- a/app/views/galleries/images/_tag.html.erb
+++ b/app/views/galleries/images/_tag.html.erb
@@ -2,7 +2,7 @@
   <div class="flex gap-3 items-center">
     <div>
       <%= link_to(
-        tag.name,
+        tag.display_name,
         gallery_tag_path(@gallery, tag),
         data: {turbo: false}
       ) %>

--- a/app/views/galleries/images/tag_searches/_form.html.erb
+++ b/app/views/galleries/images/tag_searches/_form.html.erb
@@ -34,7 +34,7 @@
     <% Array(tag_search.results).each do |tag| %>
       <%= turbo_frame_tag("tag-search-result-#{tag.id}") do %>
         <div class="flex gap-4 my-2">
-          <%= tag.name %>
+          <%= tag.display_name %>
           <%= button_to(
             "Add tag",
             gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
@@ -48,7 +48,7 @@
     <% @gallery.recently_used_tags.each do |tag| %>
       <%= turbo_frame_tag("recently-added-tag-#{tag.id}") do %>
         <div class="flex gap-4 my-2">
-          <%= tag.name %>
+          <%= tag.display_name %>
           <%= button_to(
             "Add tag",
             gallery_image_tags_path(@gallery, @image, tag_id: tag.id),

--- a/app/views/galleries/tags/index.html.erb
+++ b/app/views/galleries/tags/index.html.erb
@@ -21,7 +21,7 @@
       gallery_tag_path(@gallery, tag),
       data: {role: "tag"}
     ) do %>
-      <div><%= tag.name %> </div>
+      <div><%= tag.display_name %> </div>
     <% end %>
   <% end %>
 

--- a/app/views/galleries/tags/show.html.erb
+++ b/app/views/galleries/tags/show.html.erb
@@ -25,6 +25,10 @@
   <% end %>
 <% end %>
 
+<% if @images.none? %>
+  <div>This tag has no images.</div>
+<% end %>
+
 <%= render(
   partial: "galleries/images",
   locals: {images: @images}

--- a/db/migrate/20241206163613_add_counter_cache_to_tags.rb
+++ b/db/migrate/20241206163613_add_counter_cache_to_tags.rb
@@ -1,0 +1,19 @@
+class AddCounterCacheToTags < ActiveRecord::Migration[7.2]
+  def change
+    add_column(
+      :galleries_tags,
+      :image_tags_count,
+      :integer,
+      default: 0,
+      null: false
+    )
+
+    reversible do |dir|
+      dir.up do
+        Galleries::Tag.pluck(:id).each do |id|
+          Galleries::Tag.reset_counters(id, :image_tags)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_16_154940) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_06_163613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -86,6 +86,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_16_154940) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "image_tags_count", default: 0, null: false
     t.index ["gallery_id", "name"], name: "index_galleries_tags_on_gallery_id_and_name", unique: true
     t.index ["gallery_id"], name: "index_galleries_tags_on_gallery_id"
     t.index ["user_id"], name: "index_galleries_tags_on_user_id"

--- a/spec/factories/galleries/tags.rb
+++ b/spec/factories/galleries/tags.rb
@@ -2,12 +2,13 @@
 #
 # Table name: galleries_tags
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  gallery_id :bigint           not null
-#  user_id    :bigint           not null
+#  id               :bigint           not null, primary key
+#  image_tags_count :integer          default(0), not null
+#  name             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  gallery_id       :bigint           not null
+#  user_id          :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/galleries/tag_spec.rb
+++ b/spec/models/galleries/tag_spec.rb
@@ -2,12 +2,13 @@
 #
 # Table name: galleries_tags
 #
-#  id         :bigint           not null, primary key
-#  name       :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  gallery_id :bigint           not null
-#  user_id    :bigint           not null
+#  id               :bigint           not null, primary key
+#  image_tags_count :integer          default(0), not null
+#  name             :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  gallery_id       :bigint           not null
+#  user_id          :bigint           not null
 #
 # Indexes
 #
@@ -33,5 +34,16 @@ RSpec.describe Galleries::Tag, type: :model do
     expect(build(:galleries_tag))
       .to validate_uniqueness_of(:name)
       .scoped_to(:gallery_id)
+  end
+
+  describe "#display_name" do
+    it "is the name plus the number of times it's been used" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:, name: "blah")
+      image = create(:galleries_image, gallery:)
+      image.add_tag(tag)
+
+      expect(tag.display_name).to eql("blah (1)")
+    end
   end
 end

--- a/spec/requests/galleries/tags_controller_spec.rb
+++ b/spec/requests/galleries/tags_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Galleries::TagsController do
         page
           .all("[data-role=tag]")
           .map { _1.text.strip }
-      expect(tags).to eql([tag_a.name, tag_b.name])
+      expect(tags).to eql([tag_a.display_name, tag_b.display_name])
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,8 @@ RSpec.configure do |config|
   # inherited by the metadata hash of host groups and examples, rather than
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
+  config.disable_monkey_patching!
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.


### PR DESCRIPTION
When displaying a tag, also display the number of times it's been used in parenthesis, e.g. `tag (4)`

Add a conter cache to support querying this efficiently, and backfill existing counters.