### PR TITLE
Fix tag ordering on image show

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,5 +64,6 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "shoulda-matchers"
+  gem "super_diff"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    attr_extras (7.1.0)
     aws-eventstream (1.3.0)
     aws-partitions (1.1022.0)
     aws-sdk-core (3.214.0)
@@ -221,10 +222,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.1-x86_64-linux-gnu)
       racc (~> 1.4)
+    optimist (3.2.0)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.5.9)
     psych (5.2.2)
       date
@@ -367,6 +371,10 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
+    super_diff (0.14.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     tailwindcss-rails (3.1.0)
       railties (>= 7.0.0)
       tailwindcss-ruby
@@ -448,6 +456,7 @@ DEPENDENCIES
   stackprof
   standard
   stimulus-rails
+  super_diff
   tailwindcss-rails
   turbo-rails
   tzinfo-data

--- a/app/views/galleries/images/_tag.html.erb
+++ b/app/views/galleries/images/_tag.html.erb
@@ -1,10 +1,13 @@
-<%= turbo_frame_tag(tag) do %>
+<%= turbo_frame_tag(tag, data: {role: "tag"}) do %>
   <div class="flex gap-3 items-center">
     <div>
       <%= link_to(
         tag.display_name,
         gallery_tag_path(@gallery, tag),
-        data: {turbo: false}
+        data: {
+          turbo: false,
+          role: "tag-link"
+        }
       ) %>
     </div>
     <%= button_to(

--- a/app/views/galleries/images/_tags.html.erb
+++ b/app/views/galleries/images/_tags.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag("image-tags") do %>
-  <div class="flex mb-5 flex-col gap-3">
-    <%= render(partial: "galleries/images/tag", collection: @image.tags) %>
+  <div class="flex mb-5 flex-col gap-3" data-role="tags">
+    <%= render(partial: "galleries/images/tag", collection: tags) %>
     <span class="hidden only:block">
       This image doesn't have any tags yet.
     </span>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,7 @@ require "capybara/rspec"
 require "view_component/system_test_helpers"
 require "view_component/test_helpers"
 require "webmock/rspec"
+require "super_diff/rspec-rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { require _1 }
 

--- a/spec/requests/galleries/images_controller_spec.rb
+++ b/spec/requests/galleries/images_controller_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe Galleries::ImagesController do
       expect(page).to have_link("Galleries", href: galleries_path)
       expect(page).to have_link(gallery.name, href: gallery_path(gallery))
     end
+
+    it "shows tags sorted by name" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      tag2 = create(:galleries_tag, gallery:, name: "tag 2")
+      tag1 = create(:galleries_tag, gallery:, name: "tag 1")
+      image.add_tag(tag2)
+      image.add_tag(tag1)
+      login_as(user)
+
+      get(gallery_image_path(gallery, image))
+
+      tags = page.all("[data-role=tag-link]").map { _1.text.strip }
+      expect(tags).to eql(["tag 1 (1)", "tag 2 (1)"])
+    end
   end
 
   describe "update" do


### PR DESCRIPTION
On the image show page, tags which were applied to the image did not appear in the correct order.

Also add super_diff gem, which displays better diffs when tests fail