### PR TITLE
Tagging needed job

### DIFF
--- a/app/jobs/galleries/tagging_needed_job.rb
+++ b/app/jobs/galleries/tagging_needed_job.rb
@@ -1,0 +1,20 @@
+module Galleries
+  class TaggingNeededJob < ApplicationJob
+    queue_as :background
+
+    def perform
+      Gallery.find_each { apply_tagging_needed(_1) }
+    end
+
+    private
+
+    def apply_tagging_needed(gallery)
+      tag = Galleries::Tag.tagging_needed(gallery)
+
+      gallery
+        .images
+        .where.missing(:tags)
+        .find_each { _1.add_tag(tag) }
+    end
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,3 +1,6 @@
 reschedule_rollable_tasks:
   class: "Todoist::RescheduleRollableTasksJob"
   schedule: "0 * * * *"
+tagging_needed:
+  class: "Galleries::TaggingNeededJob"
+  schedule: "10 * * * *"

--- a/spec/jobs/galleries/tagging_needed_job_spec.rb
+++ b/spec/jobs/galleries/tagging_needed_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Galleries::TaggingNeededJob, "#perform" do
+  it "adds 'tagging needed' to images" do
+    gallery = create(:gallery)
+    image = create(:galleries_image, gallery:)
+
+    described_class.new.perform
+
+    expect(image.tags.pluck(:name)).to eql(["tagging needed"])
+  end
+
+  it "does not add the tag to images which have tags" do
+    gallery = create(:gallery)
+    image = create(:galleries_image, gallery:)
+    some_other_tag = create(:galleries_tag, gallery:)
+    image.add_tag(some_other_tag)
+
+    described_class.new.perform
+
+    expect(image.tags.pluck(:name)).not_to include("tagging needed")
+  end
+end


### PR DESCRIPTION
Periodically check for images without tags, then add 'tagging needed' to them. This will catch the situation where you remove 'tagging needed' but then forget to add any tags. It will also fix the gap where images added via the API were not given 'tagging needed'.