### PR TITLE
Generate variants ahead of time

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - run: sudo apt install imagemagick libvips
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/app/controllers/api/galleries/images_controller.rb
+++ b/app/controllers/api/galleries/images_controller.rb
@@ -9,6 +9,7 @@ module Api
 
         if @image.save
           @image.add_tag(tagging_needed)
+          ::Galleries::ImageVariantJob.perform_later(@image)
           render json: @image, status: :created
         else
           render json: {

--- a/app/jobs/galleries/image_variant_job.rb
+++ b/app/jobs/galleries/image_variant_job.rb
@@ -1,0 +1,11 @@
+module Galleries
+  class ImageVariantJob < ApplicationJob
+    queue_as :default
+
+    def perform(image)
+      if image.file.variable?
+        image.file.variant(:thumb).processed
+      end
+    end
+  end
+end

--- a/app/models/galleries/image.rb
+++ b/app/models/galleries/image.rb
@@ -17,7 +17,10 @@
 #
 module Galleries
   class Image < ActiveRecord::Base
-    has_one_attached :file
+    has_one_attached :file do |file|
+      file.variant(:thumb, resize_to_limit: [200, 200])
+    end
+
     belongs_to :gallery
     has_many :image_tags,
       class_name: "Galleries::ImageTag",

--- a/app/views/galleries/_image.html.erb
+++ b/app/views/galleries/_image.html.erb
@@ -4,7 +4,7 @@
 ) do %>
   <div class="flex justify-center">
     <% if image.file.variable? %>
-      <%= image_tag(image.file.variant(resize_to_limit: [200, 200])) %>
+      <%= image_tag(image.file.variant(:thumb)) %>
     <% else %>
       <%= image_tag(image.file) %>
     <% end %>

--- a/spec/jobs/galleries/image_variant_job_spec.rb
+++ b/spec/jobs/galleries/image_variant_job_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Galleries::ImageVariantJob do
+  describe "#perform" do
+    it "genreates a variant for the image" do
+      image = create(:galleries_image)
+      variant = image.file.variant(:thumb)
+
+      described_class.new.perform(image)
+
+      expect(variant.blob).to be_present
+    end
+
+    it "does nothing if the file is not variable" do
+      image = create(
+        :galleries_image,
+        file: Rack::Test::UploadedFile.new(
+          fixture_file_upload("testing.pdf")
+        )
+      )
+
+      expect {
+        described_class.new.perform(image)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/models/galleries/bulk_upload_spec.rb
+++ b/spec/models/galleries/bulk_upload_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Galleries::BulkUpload do
       image = gallery.images.first
       expect(image.tags.pluck(:name)).to eql(["tagging needed"])
     end
+
+    it "generates image variants" do
+      gallery = create(:gallery)
+      bulk_upload = described_class.new(gallery:, files: [audiosurf_jpg])
+
+      result = bulk_upload.save
+
+      expect(result).to be(true)
+      image = gallery.images.first
+      expect(image.file.variant(:thumb).blob).to be_present
+    end
   end
 
   private


### PR DESCRIPTION
Pages display lots of images, so the first time you visit a page, you can potentially wait quite a while for all of the thumbnail variants to be generated and stored. To fix that, this generates the thumbnail variant immediatley when an image is uploaded, so it's ready to go right away.