### PR TITLE
Clear tag search field when selecting result

### DIFF
--- a/app/views/galleries/images/show.html.erb
+++ b/app/views/galleries/images/show.html.erb
@@ -35,17 +35,10 @@
 <div class="flex flex-col">
   <%= render(partial: "tags", locals: {tags: @image.tags.order(:name)}) %>
 
-  <turbo-frame id="tag-search">
-    <%= render(
-      partial: "galleries/images/tag_searches/form",
-      locals: {
-        tag_search: Galleries::Images::TagSearch.new(
-          gallery: @gallery,
-          image: @image
-        )
-      }
-    ) %>
-  </turbo-frame>
+  <%= render(Galleries::Images::TagSearch.new(
+    gallery: @gallery,
+    image: @image
+  )) %>
 </div>
 
 <div class="pb-32"></div>

--- a/app/views/galleries/images/tag_searches/_form.html.erb
+++ b/app/views/galleries/images/tag_searches/_form.html.erb
@@ -1,61 +1,24 @@
-<%= turbo_frame_tag("tag-search") do %>
-  <h3 class="text-lg mb-3">Add tag</h3>
-
+<%= turbo_frame_tag("tag-search-form") do %>
   <%= simple_form_for(
     tag_search,
-    url: gallery_image_tag_search_path(@gallery, @image),
+    url: gallery_image_tag_search_path(gallery, image),
     method: :get,
+    html: {
+      data: {turbo_frame: "tag-search"}
+    }
   ) do |form| %>
     <div class="flex w-full gap-3">
       <%= form.input(
         :query,
         label: false,
         wrapper_html: {class: "grow"},
-        input_html: {autocorrect: "off", autocomplete: "off"}
+        input_html: {
+          autocorrect: "off",
+          autocomplete: "off",
+          aria: {label: "Tag search query"},
+        }
       ) %>
       <%= form.button(:submit, "Search") %>
     </div>
   <% end %>
-
-  <div>
-    <% if tag_search.query.present? %>
-      <%= simple_form_for(
-        [@gallery, Galleries::Tag.new(name: tag_search.query)],
-        html: {
-          data: {turbo: false}
-        },
-        url: gallery_tags_path(@gallery, add_to_image_id: @image.id)
-      ) do |f| %>
-        <%= f.input(:name, as: :hidden) %>
-        <%= f.button(:submit, "Create new tag") %>
-      <% end %>
-    <% end %>
-
-    <% Array(tag_search.results).each do |tag| %>
-      <%= turbo_frame_tag("tag-search-result-#{tag.id}") do %>
-        <div class="flex gap-4 my-2">
-          <%= tag.display_name %>
-          <%= button_to(
-            "Add tag",
-            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
-            class: "button"
-          ) %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <h4 class="text-md mt-10">Recently used tags</h4>
-    <% @gallery.recently_used_tags(excluded_image_ids: [@image.id]).each do |tag| %>
-      <%= turbo_frame_tag("recently-added-tag-#{tag.id}") do %>
-        <div class="flex gap-4 my-2">
-          <%= tag.display_name %>
-          <%= button_to(
-            "Add tag",
-            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
-            class: "button"
-          ) %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
 <% end %>

--- a/app/views/galleries/images/tag_searches/_tag_search.html.erb
+++ b/app/views/galleries/images/tag_searches/_tag_search.html.erb
@@ -1,0 +1,54 @@
+<%= turbo_frame_tag("tag-search") do %>
+  <h3 class="text-lg mb-3">Add tag</h3>
+
+  <%= render(
+    partial: "galleries/images/tag_searches/form",
+    locals: {
+      tag_search:,
+      gallery: @gallery,
+      image: @image
+    }
+  ) %>
+
+  <div>
+    <% if tag_search.query.present? %>
+      <%= simple_form_for(
+        [@gallery, Galleries::Tag.new(name: tag_search.query)],
+        html: {
+          data: {turbo: false}
+        },
+        url: gallery_tags_path(@gallery, add_to_image_id: @image.id)
+      ) do |f| %>
+        <%= f.input(:name, as: :hidden) %>
+        <%= f.button(:submit, "Create new tag") %>
+      <% end %>
+    <% end %>
+
+    <% Array(tag_search.results).each do |tag| %>
+      <%= turbo_frame_tag("tag-search-result-#{tag.id}") do %>
+        <div class="flex gap-4 my-2" data-role="tag-search-result">
+          <%= tag.display_name %>
+          <%= button_to(
+            "Add tag",
+            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
+            class: "button"
+          ) %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <h4 class="text-md mt-10">Recently used tags</h4>
+    <% @gallery.recently_used_tags(excluded_image_ids: [@image.id]).each do |tag| %>
+      <%= turbo_frame_tag("recently-added-tag-#{tag.id}") do %>
+        <div class="flex gap-4 my-2">
+          <%= tag.display_name %>
+          <%= button_to(
+            "Add tag",
+            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
+            class: "button"
+          ) %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/galleries/images/tag_searches/show.html.erb
+++ b/app/views/galleries/images/tag_searches/show.html.erb
@@ -1,4 +1,1 @@
-<%= render(
-  partial: "form",
-  locals: {tag_search: @tag_search}
-) %>
+<%= render(@tag_search) %>

--- a/app/views/galleries/images/tags/create.turbo_stream.erb
+++ b/app/views/galleries/images/tags/create.turbo_stream.erb
@@ -3,5 +3,14 @@
   partial: "galleries/images/tags",
   locals: { tags: @image.tags }
 ) %>
+<%= turbo_stream.update(
+  "tag-search-form",
+  partial: "galleries/images/tag_searches/form",
+  locals: {
+    tag_search: Galleries::Images::TagSearch.new,
+    gallery: @image.gallery,
+    image: @image
+  }
+) %>
 <%= turbo_stream.remove("tag-search-result-#{@tag.id}") %>
 <%= turbo_stream.remove("recently-added-tag-#{@tag.id}") %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,3 +82,5 @@ Shoulda::Matchers.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)
+
+Capybara.enable_aria_label = true

--- a/spec/system/todo/galleries/image_tags_spec.rb
+++ b/spec/system/todo/galleries/image_tags_spec.rb
@@ -11,9 +11,13 @@ RSpec.describe "Gallery image tags", type: :system do
     visit(gallery_image_path(gallery, image))
 
     click_on("Search")
-    within("turbo-frame#tag-search-result-#{tag.id}") do
+    within("[data-role=tag-search-result]", text: tag.name) do
       click_on("Add tag")
     end
+    expect(page).not_to have_css(
+      "[data-role=tag-search-result]",
+      text: tag.name
+    )
 
     within("turbo-frame#tag_#{tag.id}", text: tag.name) do
       expect(image.reload.tags).to include(tag)
@@ -24,5 +28,29 @@ RSpec.describe "Gallery image tags", type: :system do
 
     expect(page).not_to have_css("turbo-frame#tag_#{tag.id}")
     expect(image.reload.tags).to be_empty
+  end
+
+  it "clears the search input when adding a tag", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    tag1 = create(:galleries_tag, gallery:, name: "testing 1")
+    tag2 = create(:galleries_tag, gallery:, name: "testing 2")
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "testing")
+    click_on("Search")
+
+    within("[data-role=tag-search-result]", text: tag1.name) do
+      click_on("Add tag")
+    end
+    expect(page).to have_field("Tag search query", with: "")
+
+    expect(page).to have_css(
+      "[data-role=tag-search-result]",
+      text: tag2.name
+    )
   end
 end


### PR DESCRIPTION
When you click "Add tag" next to one of the results of a tag search, clear the search input. This will make it easier to search for the next tag. Note that this just clears the search input. It doesn't remove the search results.