### PR TITLE
Keep input focus when autosearching

### DIFF
--- a/app/controllers/galleries/images/tag_searches_controller.rb
+++ b/app/controllers/galleries/images/tag_searches_controller.rb
@@ -11,6 +11,11 @@ module Galleries
           image: @image,
           query: tag_search_params[:query]
         )
+
+        respond_to do |format|
+          format.turbo_stream
+          format.html { render "galleries/images/show" }
+        end
       end
 
       private

--- a/app/controllers/galleries/images_controller.rb
+++ b/app/controllers/galleries/images_controller.rb
@@ -9,6 +9,11 @@ module Galleries
     def show
       @gallery = find_gallery
       @image = find_image
+      @tag_search = Galleries::Images::TagSearch.new(
+        gallery: @gallery,
+        image: @image,
+        query: params[:tag_query]
+      )
     end
 
     def edit

--- a/app/javascript/controllers/auto_submit_form_controller.js
+++ b/app/javascript/controllers/auto_submit_form_controller.js
@@ -1,19 +1,21 @@
 import { Controller } from "@hotwired/stimulus"
 import debounce from "just-debounce"
-import { isProduction } from "util/rails_env"
+import { isTest } from "util/rails_env"
 
 export default class extends Controller {
-  submit(event) {
-    if (event.target.value.length <= 3) {
-      return
-    }
+  connect() {
+    this.debouncedSubmit = debounce((event) => {
+      if (event.target.value.length > 3) {
+        this.element.requestSubmit()
+      }
+    }, this.timeoutDuration())
+  }
 
-    debounce(() => {
-      this.element.requestSubmit()
-    }, this.timeoutDuration())()
+  submit(event) {
+    this.debouncedSubmit(event)
   }
 
   timeoutDuration() {
-    return isProduction() ? 750 : 50;
+    return isTest() ? 50 : 250;
   }
 }

--- a/app/javascript/util/rails_env.js
+++ b/app/javascript/util/rails_env.js
@@ -4,6 +4,6 @@ export function railsEnv() {
     ?.getAttribute("content")
 }
 
-export function isProduction() {
-  return railsEnv() === "production"
+export function isTest() {
+  return railsEnv() === "test"
 }

--- a/app/models/galleries/images/tag_search.rb
+++ b/app/models/galleries/images/tag_search.rb
@@ -8,11 +8,13 @@ module Galleries
       attr_accessor :query
 
       def results
-        return Tag.none if query.nil?
+        ilike = query&.strip
+        return Tag.none if ilike.nil?
+        ilike = ActiveRecord::Base.sanitize_sql_like(ilike)
 
         gallery
           .tags
-          .where("galleries_tags.name ILIKE ?", "%#{query.strip}%")
+          .where("galleries_tags.name ILIKE ?", "%#{ilike}%")
           .where.not(id: image.tags.select(:id))
           .order(Galleries::Tag.arel_table[:name])
       end

--- a/app/views/galleries/images/show.html.erb
+++ b/app/views/galleries/images/show.html.erb
@@ -33,12 +33,11 @@
 <h2 class="text-xl mt-10 mb-5">Tags</h2>
 
 <div class="flex flex-col">
-  <%= render(partial: "tags", locals: {tags: @image.tags.order(:name)}) %>
-
-  <%= render(Galleries::Images::TagSearch.new(
-    gallery: @gallery,
-    image: @image
-  )) %>
+  <%= render(
+    partial: "galleries/images/tags",
+    locals: {tags: @image.tags.order(:name)}
+  ) %>
+  <%= render(@tag_search) %>
 </div>
 
 <div class="pb-32"></div>

--- a/app/views/galleries/images/tag_searches/_form.html.erb
+++ b/app/views/galleries/images/tag_searches/_form.html.erb
@@ -5,7 +5,7 @@
     method: :get,
     html: {
       data: {
-        turbo_frame: "tag-search",
+        turbo_frame: "tag-search-results",
         controller: "auto-submit-form"
       }
     }

--- a/app/views/galleries/images/tag_searches/_results.html.erb
+++ b/app/views/galleries/images/tag_searches/_results.html.erb
@@ -1,0 +1,41 @@
+<%= turbo_frame_tag("tag-search-results") do %>
+  <% if tag_search.query.present? %>
+    <%= simple_form_for(
+      [gallery, Galleries::Tag.new(name: tag_search.query)],
+      html: {
+        data: {turbo: false}
+      },
+      url: gallery_tags_path(gallery, add_to_image_id: image.id)
+    ) do |f| %>
+      <%= f.input(:name, as: :hidden) %>
+      <%= f.button(:submit, "Create tag \"#{tag_search.query}\"") %>
+    <% end %>
+  <% end %>
+
+  <% Array(tag_search.results).each do |tag| %>
+    <%= turbo_frame_tag("tag-search-result-#{tag.id}") do %>
+      <div class="flex gap-4 my-2" data-role="tag-search-result">
+        <%= tag.display_name %>
+        <%= button_to(
+          "Add tag",
+          gallery_image_tags_path(gallery, image, tag_id: tag.id),
+          class: "button"
+        ) %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <h4 class="text-md mt-10">Recently used tags</h4>
+  <% gallery.recently_used_tags(excluded_image_ids: [image.id]).each do |tag| %>
+    <%= turbo_frame_tag("recently-added-tag-#{tag.id}") do %>
+      <div class="flex gap-4 my-2">
+        <%= tag.display_name %>
+        <%= button_to(
+          "Add tag",
+          gallery_image_tags_path(gallery, image, tag_id: tag.id),
+          class: "button"
+        ) %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/galleries/images/tag_searches/_tag_search.html.erb
+++ b/app/views/galleries/images/tag_searches/_tag_search.html.erb
@@ -1,54 +1,19 @@
-<%= turbo_frame_tag("tag-search") do %>
-  <h3 class="text-lg mb-3">Add tag</h3>
+<h3 class="text-lg mb-3">Add tag</h3>
 
-  <%= render(
-    partial: "galleries/images/tag_searches/form",
-    locals: {
-      tag_search:,
-      gallery: @gallery,
-      image: @image
-    }
-  ) %>
+<%= render(
+  partial: "galleries/images/tag_searches/form",
+  locals: {
+    tag_search:,
+    gallery: @gallery,
+    image: @image
+  }
+) %>
 
-  <div>
-    <% if tag_search.query.present? %>
-      <%= simple_form_for(
-        [@gallery, Galleries::Tag.new(name: tag_search.query)],
-        html: {
-          data: {turbo: false}
-        },
-        url: gallery_tags_path(@gallery, add_to_image_id: @image.id)
-      ) do |f| %>
-        <%= f.input(:name, as: :hidden) %>
-        <%= f.button(:submit, "Create new tag") %>
-      <% end %>
-    <% end %>
-
-    <% Array(tag_search.results).each do |tag| %>
-      <%= turbo_frame_tag("tag-search-result-#{tag.id}") do %>
-        <div class="flex gap-4 my-2" data-role="tag-search-result">
-          <%= tag.display_name %>
-          <%= button_to(
-            "Add tag",
-            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
-            class: "button"
-          ) %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <h4 class="text-md mt-10">Recently used tags</h4>
-    <% @gallery.recently_used_tags(excluded_image_ids: [@image.id]).each do |tag| %>
-      <%= turbo_frame_tag("recently-added-tag-#{tag.id}") do %>
-        <div class="flex gap-4 my-2">
-          <%= tag.display_name %>
-          <%= button_to(
-            "Add tag",
-            gallery_image_tags_path(@gallery, @image, tag_id: tag.id),
-            class: "button"
-          ) %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-<% end %>
+<%= render(
+  partial: "galleries/images/tag_searches/results",
+  locals: {
+    tag_search:,
+    gallery: @gallery,
+    image: @image
+  }
+) %>

--- a/app/views/galleries/images/tag_searches/show.turbo_stream.erb
+++ b/app/views/galleries/images/tag_searches/show.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= turbo_stream.replace(
+  "tag-search-results",
+  partial: "galleries/images/tag_searches/results",
+  locals: {
+    tag_search: @tag_search,
+    gallery: @gallery,
+    image: @image
+  }
+) %>

--- a/spec/system/todo/galleries/image_tags_spec.rb
+++ b/spec/system/todo/galleries/image_tags_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe "Gallery image tags", type: :system do
     expect(image.reload.tags).to be_empty
   end
 
+  it "can add and remove tags without JS" do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    tag = create(:galleries_tag, gallery:)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    click_on("Search")
+    within("[data-role=tag-search-result]", text: tag.name) do
+      click_on("Add tag")
+    end
+    expect(page).not_to have_css(
+      "[data-role=tag-search-result]",
+      text: tag.name
+    )
+
+    within("turbo-frame#tag_#{tag.id}", text: tag.name) do
+      expect(image.reload.tags).to include(tag)
+      click_on("Remove")
+    end
+
+    expect(page).not_to have_css("turbo-frame#tag_#{tag.id}")
+    expect(image.reload.tags).to be_empty
+  end
+
   it "clears the search input when adding a tag", :js do
     user = create(:user)
     gallery = create(:gallery, user:)


### PR DESCRIPTION
Previously when the search was auto submitted, the resulting response included both the search form and the results. This lead to turbo replacing both of those elements in the page, meaning your cursor would lose focus from the search input.

In reality the only parts of the page that change are the search results, so now only those are sent back. This way your cursor should keep focus as you expect.

I also fixed an issue where the respose of the TagSearches#show only included the tag search form, not the entire page. This meant that if for some reason turbo didn't work, you'd be redirected to a page with just the search form and nothing else. Now you should end up on the correct page regardless of whether you're using turbo or not.