### PR TITLE
Remove sentry-ruby dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "warden"
 
 # Sentry
 gem "stackprof"
-gem "sentry-ruby"
 gem "sentry-rails"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,6 @@ DEPENDENCIES
   rspec-rails
   selenium-webdriver
   sentry-rails
-  sentry-ruby
   shoulda-matchers
   simple_form
   solid_queue


### PR DESCRIPTION
This is a dependency of sentry-rails so it gets updated anyway. This will prevent dependabot updates for this gem.