### PR TITLE
Auto submit search on 3+ chars

### DIFF
--- a/app/javascript/controllers/auto_submit_form_controller.js
+++ b/app/javascript/controllers/auto_submit_form_controller.js
@@ -5,7 +5,7 @@ import { isTest } from "util/rails_env"
 export default class extends Controller {
   connect() {
     this.debouncedSubmit = debounce((event) => {
-      if (event.target.value.length > 3) {
+      if (event.target.value.length > 2) {
         this.element.requestSubmit()
       }
     }, this.timeoutDuration())

--- a/spec/system/todo/galleries/image_tags_spec.rb
+++ b/spec/system/todo/galleries/image_tags_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe "Gallery image tags", type: :system do
     visit(gallery_image_path(gallery, image))
 
     # does not auto submit short query
-    fill_in("Tag search query", with: "tag")
+    fill_in("Tag search query", with: "ta")
     expect(page).not_to have_css("[data-role=tag-search-result]", text: tag.name)
 
-    # auto submits after 3 characters
-    fill_in("Tag search query", with: "tagg")
+    # auto submits after 2 characters
+    fill_in("Tag search query", with: "tag")
     expect(page).to have_css("[data-role=tag-search-result]", text: tag.name)
   end
 end


### PR DESCRIPTION
Instead of 4+ chars, switch to 3+ chars. There are a few 3 character tags that come up frequently and it's annoying to have to press enter to search for those.