### PR TITLE
Suggested images considers tag frequency

### DIFF
--- a/app/models/galleries/similar_images.rb
+++ b/app/models/galleries/similar_images.rb
@@ -17,9 +17,29 @@ module Galleries
     attr_reader :image
 
     def similar_images
-      Galleries::Image
-        .joins(:tags)
-        .where(tags: {id: image.tag_ids})
+      cluster =
+        Galleries::Image
+          .joins(:tags)
+          .where(tags: {id: image.tag_ids})
+          .where.not(id: image.id)
+
+      this_weighted_tags = weighted_tags(image)
+
+      cluster.sort_by do |other|
+        other_weighted_tags = weighted_tags(other)
+
+        (this_weighted_tags.keys & other_weighted_tags.keys).sum do |tag|
+          this_weighted_tags[tag] * other_weighted_tags[tag]
+        end
+      end.reverse
+    end
+
+    def weighted_tags(image)
+      image.tags.each_with_object({}) do |tag, acc|
+        tag_count = tag.image_tags_count
+        weight = tag_count.zero? ? 1.0 : 1.0 / tag_count
+        acc[tag] = weight
+      end
     end
   end
 end


### PR DESCRIPTION
Try a new algorithm which considers the frequency at which tag occurs. Less common tags are given higher weight. If this works I'll almost certainly want to cache it.