### PR TITLE
Update url when paginating

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -5,6 +5,7 @@ class GalleriesController < ApplicationController
     @galleries = current_user.galleries.visible
   end
 
+  PER_PAGE = 20
   def show
     @gallery = find_gallery
     @filter_tags = find_filter_tags
@@ -15,6 +16,7 @@ class GalleriesController < ApplicationController
         .order(created_at: :desc)
         .then { @filter_tags.any? ? it.by_tags(@filter_tags) : it }
         .page(params[:page])
+        .per(PER_PAGE)
     @tag_search = Galleries::TagSearch.new(
       gallery: @gallery,
       query: params.dig(:tag_search, :query)

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -1,4 +1,4 @@
-<div class="">
+<div>
   <h2 class="text-xl mb-5">Filter by tag</h2>
 
   <div class="flex mb-4 gap-2 flex-wrap">

--- a/app/views/galleries/_images.html.erb
+++ b/app/views/galleries/_images.html.erb
@@ -7,6 +7,6 @@
   </div>
 
   <div class="flex justify-center">
-    <%= paginate images %>
+    <%= paginate(images) %>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, data: {turbo_action: :advance} %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, data: {turbo_action: :advance} %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, data: {turbo_action: :advance} %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, data: {turbo_action: :advance}} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, data: {turbo_action: :advance} %>
+</span>

--- a/spec/system/galleries/show_spec.rb
+++ b/spec/system/galleries/show_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Gallery show page" do
+  it "paginates" do
+    stub_const("GalleriesController::PER_PAGE", 1)
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image1, image2 = create_pair(:galleries_image, gallery:)
+    login_as(user)
+
+    visit(gallery_path(gallery))
+
+    expect(page).not_to have_css("[data-image-id='#{image1.id}']")
+    expect(page).to have_css("[data-image-id='#{image2.id}']")
+
+    click_on("Next ›")
+
+    expect(page).to have_css("[data-image-id='#{image1.id}']")
+    expect(page).not_to have_css("[data-image-id='#{image2.id}']")
+    expect(URI.parse(current_url).query).to eql("page=2")
+  end
+end


### PR DESCRIPTION
When navigating to the next page of images, update the URL with the current page number. Previously this didn't happen and if you refreshed your browser, it would forget what page you were on. To fix this I asked turbo to update the URL when performing updates.