### PR TITLE
Add ApplicationComponent

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,0 +1,4 @@
+class ApplicationComponent < ViewComponent::Base
+  include Rails.application.routes.url_helpers
+  include Turbo::FramesHelper
+end

--- a/app/components/flash_component.rb
+++ b/app/components/flash_component.rb
@@ -1,4 +1,4 @@
-class FlashComponent < ViewComponent::Base
+class FlashComponent < ApplicationComponent
   erb_template <<~ERB
     <%= tag.div(
       @message,

--- a/app/components/galleries/image_component.rb
+++ b/app/components/galleries/image_component.rb
@@ -1,7 +1,5 @@
 module Galleries
-  class ImageComponent < ViewComponent::Base
-    include Rails.application.routes.url_helpers
-
+  class ImageComponent < ApplicationComponent
     erb_template <<~ERB
       <div data-role="image" data-image-id='<%= @image.id %>'>
         <% if @image.video? %>

--- a/app/components/galleries/image_tag_search_component.rb
+++ b/app/components/galleries/image_tag_search_component.rb
@@ -1,8 +1,5 @@
 module Galleries
-  class ImageTagSearchComponent < ViewComponent::Base
-    include Rails.application.routes.url_helpers
-    include Turbo::FramesHelper
-
+  class ImageTagSearchComponent < ApplicationComponent
     erb_template <<~ERB
       <h3 class="text-lg mb-3">Add tag</h3>
 

--- a/app/components/galleries/image_tags_component.rb
+++ b/app/components/galleries/image_tags_component.rb
@@ -1,8 +1,5 @@
 module Galleries
-  class ImageTagsComponent < ViewComponent::Base
-    include Rails.application.routes.url_helpers
-    include Turbo::FramesHelper
-
+  class ImageTagsComponent < ApplicationComponent
     erb_template <<~ERB
       <%= turbo_frame_tag("image-tags") do %>
         <div class="flex mb-5 flex-col gap-3" data-role="tags">

--- a/app/components/galleries/image_thumbnail_component.rb
+++ b/app/components/galleries/image_thumbnail_component.rb
@@ -1,7 +1,5 @@
 module Galleries
-  class ImageThumbnailComponent < ViewComponent::Base
-    include Rails.application.routes.url_helpers
-
+  class ImageThumbnailComponent < ApplicationComponent
     erb_template <<~ERB
       <%= link_to(
         gallery_image_path(@gallery, @image),

--- a/app/components/galleries/similar_images_component.rb
+++ b/app/components/galleries/similar_images_component.rb
@@ -1,7 +1,5 @@
 module Galleries
-  class SimilarImagesComponent < ViewComponent::Base
-    include Rails.application.routes.url_helpers
-
+  class SimilarImagesComponent < ApplicationComponent
     erb_template <<~ERB
       <div data-role="similar-images">
         <h2 class="text-xl mb-4"><%= @title %></h2>

--- a/app/components/galleries/tag_searches/form_component.rb
+++ b/app/components/galleries/tag_searches/form_component.rb
@@ -1,9 +1,6 @@
 module Galleries
   module TagSearches
-    class FormComponent < ViewComponent::Base
-      include Rails.application.routes.url_helpers
-      include Turbo::FramesHelper
-
+    class FormComponent < ApplicationComponent
       erb_template <<~ERB
         <%= turbo_frame_tag("tag-search-form") do %>
           <%= simple_form_for(

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,6 +1,4 @@
-class HeaderComponent < ViewComponent::Base
-  include Rails.application.routes.url_helpers
-
+class HeaderComponent < ApplicationComponent
   erb_template <<~ERB
     <div class="flex w-full mb-8 flex-col">
       <div class="flex space-x-1 w-full mb-3 text-md">


### PR DESCRIPTION
Rather than components extending `ViewComponent::Base`, they will now extend `ApplicationComponent`. This allows me to put shared logic there rather than having to duplicate it each time.