### PR TITLE
Fix clicking on a tag search result

### DIFF
--- a/app/components/galleries/tag_searches/results_component.rb
+++ b/app/components/galleries/tag_searches/results_component.rb
@@ -21,7 +21,8 @@ module Galleries
               <div class="flex gap-4 my-2" data-role="tag-search-result">
                 <%= link_to(
                   tag.display_name,
-                  gallery_tag_path(tag.gallery, tag)
+                  gallery_tag_path(tag.gallery, tag),
+                  data: {turbo: false}
                 ) %>
                 <%= button_to(
                   "Add tag",

--- a/spec/system/galleries/image_tags_spec.rb
+++ b/spec/system/galleries/image_tags_spec.rb
@@ -98,4 +98,22 @@ RSpec.describe "Gallery image tags", type: :system do
     fill_in("Tag search query", with: "tag")
     expect(page).to have_css("[data-role=tag-search-result]", text: tag.name)
   end
+
+  it "allows you to visit a tag by clicking on its search result", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    tag = create(:galleries_tag, gallery:)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: tag.name)
+    click_on("Search")
+
+    within("[data-role=tag-search-result]", text: tag.name) do
+      click_on(tag.display_name)
+    end
+    expect(current_path).to eql(gallery_tag_path(gallery, tag))
+  end
 end


### PR DESCRIPTION
The search result is a link to the tag show page. Because it was rendered within a turbo frame, however, turbo expects the page result to also contain the same turbo frame tag. Because it's a totally different page, however, that turbo frame is not present, and so the link fails.

To fix this, we set `data-turbo=false` so that a full page load is performed.