### PR TITLE
Make auto-add tag names clickable links

### DIFF
--- a/app/views/galleries/tags/show.html.erb
+++ b/app/views/galleries/tags/show.html.erb
@@ -42,7 +42,10 @@
   <% @tag.auto_add_tag_associations.each do |auto_add_tag_association| %>
     <div data-role="auto-add-tag" class="flex gap-4 mb-4">
       <div class="flex items-center">
-        <%= auto_add_tag_association.auto_add_tag.name %>
+        <%= link_to(
+          auto_add_tag_association.auto_add_tag.name,
+          gallery_tag_path(@gallery, auto_add_tag_association.auto_add_tag)
+        ) %>
       </div>
       <div class="flex items-center gap-4">
         <%= button_to(

--- a/spec/system/galleries/auto_add_tags_spec.rb
+++ b/spec/system/galleries/auto_add_tags_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe "Gallery auto add tags", type: :system do
 
     within("[data-role=auto-add-tags]") do
       expect(page).to have_content(auto_tag.name)
+      expect(page).to have_link(
+        auto_tag.name,
+        href: gallery_tag_path(gallery, auto_tag)
+      )
     end
 
     # Remove auto-add tag


### PR DESCRIPTION
Convert auto-add tag names to links in tag show page