### PR TITLE
Add authorization to Gallery SocialMediaLinksController

### DIFF
--- a/app/controllers/galleries/social_media_links_controller.rb
+++ b/app/controllers/galleries/social_media_links_controller.rb
@@ -1,18 +1,19 @@
 module Galleries
   class SocialMediaLinksController < ApplicationController
     before_action :ensure_authenticated!
+    after_action :verify_authorized
 
     def new
       @gallery = find_gallery
       @tag = find_tag(@gallery)
-      @social_media_link = @tag.social_media_links.build
+      @social_media_link = authorize(@tag.social_media_links.build)
       render :new
     end
 
     def create
       @gallery = find_gallery
       @tag = find_tag(@gallery)
-      @social_media_link = @tag.social_media_links.build(link_params)
+      @social_media_link = authorize(@tag.social_media_links.build(link_params))
 
       if @social_media_link.save
         redirect_to(
@@ -27,14 +28,14 @@ module Galleries
     def edit
       @gallery = find_gallery
       @tag = find_tag(@gallery)
-      @social_media_link = find_link(@tag)
+      @social_media_link = authorize(find_link(@tag))
       render :edit
     end
 
     def update
       @gallery = find_gallery
       @tag = find_tag(@gallery)
-      @social_media_link = find_link(@tag)
+      @social_media_link = authorize(find_link(@tag))
 
       if @social_media_link.update(link_params)
         redirect_to(
@@ -49,7 +50,7 @@ module Galleries
     def destroy
       @gallery = find_gallery
       @tag = find_tag(@gallery)
-      @social_media_link = find_link(@tag)
+      @social_media_link = authorize(find_link(@tag))
 
       @social_media_link.destroy!
       redirect_to(
@@ -61,15 +62,15 @@ module Galleries
     private
 
     def find_gallery
-      current_user.galleries.find(params[:gallery_id])
+      policy_scope(Gallery).find(params[:gallery_id])
     end
 
     def find_tag(gallery)
-      gallery.tags.find(params[:tag_id])
+      policy_scope(Galleries::Tag).where(gallery:).find(params[:tag_id])
     end
 
     def find_link(tag)
-      tag.social_media_links.find(params[:id])
+      policy_scope(Galleries::SocialMediaLink).where(tag:).find(params[:id])
     end
 
     def link_params

--- a/app/policies/galleries/social_media_link_policy.rb
+++ b/app/policies/galleries/social_media_link_policy.rb
@@ -1,0 +1,42 @@
+module Galleries
+  class SocialMediaLinkPolicy < ApplicationPolicy
+    def new?
+      user.present? && user_owns_tag?
+    end
+
+    def create?
+      user.present? && user_owns_tag?
+    end
+
+    def edit?
+      user.present? && user_owns_tag?
+    end
+
+    def update?
+      user.present? && user_owns_tag?
+    end
+
+    def destroy?
+      user.present? && user_owns_tag?
+    end
+
+    class Scope < ApplicationPolicy::Scope
+      def resolve
+        return scope.none unless user
+
+        scope
+          .joins(tag: :gallery)
+          .where(galleries_tags: {user:})
+      end
+    end
+
+    private
+
+    def user_owns_tag?
+      return false unless record.respond_to?(:tag)
+      return false unless record.tag
+
+      record.tag.user == user
+    end
+  end
+end

--- a/app/policies/galleries/social_media_link_policy.rb
+++ b/app/policies/galleries/social_media_link_policy.rb
@@ -1,23 +1,29 @@
 module Galleries
   class SocialMediaLinkPolicy < ApplicationPolicy
     def new?
-      user.present? && user_owns_tag?
+      user_owns_tag?
     end
 
     def create?
-      user.present? && user_owns_tag?
+      user_owns_tag?
     end
 
     def edit?
-      user.present? && user_owns_tag?
+      user_owns_tag?
     end
 
     def update?
-      user.present? && user_owns_tag?
+      user_owns_tag?
     end
 
     def destroy?
-      user.present? && user_owns_tag?
+      user_owns_tag?
+    end
+
+    private
+
+    def user_owns_tag?
+      user && record.tag.user == user
     end
 
     class Scope < ApplicationPolicy::Scope
@@ -28,15 +34,6 @@ module Galleries
           .joins(tag: :gallery)
           .where(galleries_tags: {user:})
       end
-    end
-
-    private
-
-    def user_owns_tag?
-      return false unless record.respond_to?(:tag)
-      return false unless record.tag
-
-      record.tag.user == user
     end
   end
 end

--- a/spec/policies/galleries/social_media_link_policy_spec.rb
+++ b/spec/policies/galleries/social_media_link_policy_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Galleries::SocialMediaLinkPolicy do
+  permissions :new?, :create?, :edit?, :update?, :destroy? do
+    it "grants access when user owns the tag" do
+      user = build(:user)
+      gallery = build(:gallery, user:)
+      tag = build(:galleries_tag, user:, gallery:)
+      social_media_link = build(:galleries_social_media_link, tag:)
+
+      expect(described_class).to permit(user, social_media_link)
+    end
+
+    it "denies access when user does not own the tag" do
+      user = build(:user)
+      other_user = build(:user)
+      gallery = build(:gallery, user: other_user)
+      tag = build(:galleries_tag, user: other_user, gallery:)
+      social_media_link = build(:galleries_social_media_link, tag:)
+
+      expect(described_class).not_to permit(user, social_media_link)
+    end
+
+    it "denies access when user is nil" do
+      gallery = build(:gallery)
+      tag = build(:galleries_tag, gallery:)
+      social_media_link = build(:galleries_social_media_link, tag:)
+
+      expect(described_class).not_to permit(nil, social_media_link)
+    end
+  end
+
+  describe described_class::Scope do
+    it "returns only social media links from tags belonging to the user" do
+      user = create(:user)
+      other_user = create(:user)
+      user_gallery = create(:gallery, user:)
+      other_gallery = create(:gallery, user: other_user)
+      user_tag = create(:galleries_tag, user:, gallery: user_gallery)
+      other_tag = create(:galleries_tag, user: other_user, gallery: other_gallery)
+      user_link = create(:galleries_social_media_link, tag: user_tag)
+      create(:galleries_social_media_link, tag: other_tag)
+
+      scope = described_class.new(user, Galleries::SocialMediaLink.all).resolve
+
+      expect(scope).to contain_exactly(user_link)
+    end
+
+    it "returns empty collection when user is nil" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      tag = create(:galleries_tag, user:, gallery:)
+      create(:galleries_social_media_link, tag:)
+
+      scope = described_class.new(nil, Galleries::SocialMediaLink.all).resolve
+
+      expect(scope).to be_empty
+    end
+  end
+end

--- a/spec/policies/galleries/social_media_link_policy_spec.rb
+++ b/spec/policies/galleries/social_media_link_policy_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe Galleries::SocialMediaLinkPolicy do
     end
 
     it "denies access when user does not own the tag" do
-      user = build(:user)
-      other_user = build(:user)
+      user, other_user = build_pair(:user)
       gallery = build(:gallery, user: other_user)
       tag = build(:galleries_tag, user: other_user, gallery:)
       social_media_link = build(:galleries_social_media_link, tag:)
@@ -32,8 +31,7 @@ RSpec.describe Galleries::SocialMediaLinkPolicy do
 
   describe described_class::Scope do
     it "returns only social media links from tags belonging to the user" do
-      user = create(:user)
-      other_user = create(:user)
+      user, other_user = create_pair(:user)
       user_gallery = create(:gallery, user:)
       other_gallery = create(:gallery, user: other_user)
       user_tag = create(:galleries_tag, user:, gallery: user_gallery)

--- a/spec/requests/galleries/social_media_links_controller_spec.rb
+++ b/spec/requests/galleries/social_media_links_controller_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe Galleries::SocialMediaLinksController do
+  describe "new" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+
+      get(new_gallery_tag_social_media_link_path(gallery, tag))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when accessing new form for tag not owned by current user" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      other_user = create(:user)
+      login_as(other_user)
+
+      get(new_gallery_tag_social_media_link_path(gallery, tag))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "create" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      params = {social_media_link: {platform: "instagram", username: "test"}}
+
+      post(gallery_tag_social_media_links_path(gallery, tag), params:)
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when creating link for tag not owned by current user" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      other_user = create(:user)
+      login_as(other_user)
+      params = {social_media_link: {platform: "instagram", username: "test"}}
+
+      post(gallery_tag_social_media_links_path(gallery, tag), params:)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "edit" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+
+      get(edit_gallery_tag_social_media_link_path(gallery, tag, link))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when editing link for tag not owned by current user" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+      other_user = create(:user)
+      login_as(other_user)
+
+      get(edit_gallery_tag_social_media_link_path(gallery, tag, link))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "update" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+      params = {social_media_link: {username: "updated"}}
+
+      put(gallery_tag_social_media_link_path(gallery, tag, link), params:)
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when updating link for tag not owned by current user" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+      other_user = create(:user)
+      login_as(other_user)
+      params = {social_media_link: {username: "updated"}}
+
+      put(gallery_tag_social_media_link_path(gallery, tag, link), params:)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "destroy" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+
+      delete(gallery_tag_social_media_link_path(gallery, tag, link))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when destroying link for tag not owned by current user" do
+      gallery = create(:gallery)
+      tag = create(:galleries_tag, gallery:)
+      link = create(:galleries_social_media_link, tag:)
+      other_user = create(:user)
+      login_as(other_user)
+
+      delete(gallery_tag_social_media_link_path(gallery, tag, link))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replaces authentication-only checks with full Pundit authorization
- Adds SocialMediaLinkPolicy with nested ownership logic (SocialMediaLink -> Tag -> Gallery -> User)
- Integrates authorization verification throughout controller actions
- Adds comprehensive policy and request spec tests

## Test plan
- [x] All existing tests pass
- [x] New policy tests verify nested ownership authorization
- [x] Request specs test authentication and authorization scenarios
- [x] 15 test examples, 0 failures