### PR TITLE
Preserve query + focus when adding gallery filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ coverage/
 .claude/settings.local.json
 
 node_modules/
+
+docs/superpowers/

--- a/app/components/galleries/tag_searches/results_component.rb
+++ b/app/components/galleries/tag_searches/results_component.rb
@@ -67,7 +67,10 @@ module Galleries
               )
             ),
             class: "button",
-            data: {turbo: false}
+            data: {
+              role: "tag-search-result-add",
+              turbo_frame: "_top"
+            }
           )
         elsif mode == :bulk_upload_tag
           helpers.button_to(

--- a/app/javascript/controllers/tag_search_filter_focus_controller.js
+++ b/app/javascript/controllers/tag_search_filter_focus_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.handleLoad = this.restoreFocus.bind(this)
+    document.addEventListener("turbo:load", this.handleLoad)
+    this.restoreFocus()
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:load", this.handleLoad)
+  }
+
+  restoreFocus() {
+    if (this.element.value) this.element.focus()
+  }
+}

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -60,6 +60,7 @@
             autocomplete: "off",
             aria: {label: "Tag search query"},
             data: {
+              controller: "tag-search-filter-focus",
               action: "input->auto-submit-form#submit",
               turbo_permanent: true
             },

--- a/spec/system/galleries/filtering_spec.rb
+++ b/spec/system/galleries/filtering_spec.rb
@@ -22,8 +22,19 @@ RSpec.describe "Gallery filtering" do
       text: tag.name
     )
     expect(page).to have_css("[data-image-id='#{image.id}']")
+    expect(page).to have_css(
+      "[data-role=tag-filter-remove-button]",
+      text: tag.name
+    )
+    expect(page).to have_field("Tag search query", with: tag.name)
+    expect(page).to have_selector(
+      "[aria-label='Tag search query']:focus"
+    )
 
-    find("[data-role=tag-filter-remove-button]", text: tag.name).click
+    find(
+      "[data-role=tag-filter-remove-button]",
+      text: tag.name
+    ).click
     expect(page).to have_css("[data-image-id='#{image.id}']")
   end
 end


### PR DESCRIPTION
## Summary
- Gallery show page: clicking **Add** on a tag search result now navigates via Turbo Drive instead of a full page reload. The search input's value is preserved via the URL params; its keyboard focus is restored by a small Stimulus controller scoped to the input.
- Replaces \`data: {turbo: false}\` on the \`:gallery\`-mode Add link with \`data: {role: "tag-search-result-add", turbo_frame: "_top"}\`. The \`_top\` frame escape is required because the link lives inside \`turbo_frame_tag("gallery-tag-search")\`; the \`data-role\` is a stable hook for a follow-up PR that adds Enter-to-add keyboard behavior.
- New controller: \`app/javascript/controllers/tag_search_filter_focus_controller.js\`. Re-focuses the search input on every \`turbo:load\` if it has a value. This is necessary because \`data-turbo-permanent\` preserves the DOM node but not keyboard focus — at click time focus is on the Add button, not the input.
- Ignores \`docs/superpowers/\` (local planning notes).