### PR TITLE
Enter-to-add filter on gallery show page

### DIFF
--- a/app/javascript/controllers/tag_search_controller.js
+++ b/app/javascript/controllers/tag_search_controller.js
@@ -13,11 +13,21 @@ export default class extends Controller {
 
     event.preventDefault()
 
+    const form = result.querySelector("form")
+    if (form) {
+      this.#submitResultForm(event, form)
+      return
+    }
+
+    const link = result.querySelector(
+      "[data-role='tag-search-result-add']"
+    )
+    if (link) link.click()
+  }
+
+  #submitResultForm(event, form) {
     const input = event.target
     const query = input.value
-
-    const form = result.querySelector("form")
-    if (!form) return
 
     const abortController = new AbortController()
     const timeout = setTimeout(

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -61,8 +61,10 @@
             aria: {label: "Tag search query"},
             data: {
               controller: "tag-search-filter-focus",
-              action: "input->auto-submit-form#submit " \
-                "keydown->tag-search#submitFirstResult",
+              action: [
+                "input->auto-submit-form#submit",
+                "keydown->tag-search#submitFirstResult"
+              ].join(" "),
               turbo_permanent: true
             },
             class: "w-full"

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div data-controller="tag-search">
   <h2 class="text-xl mb-5">Filter by tag</h2>
 
   <div class="flex mb-4 gap-2 flex-wrap">
@@ -60,8 +60,9 @@
             autocomplete: "off",
             aria: {label: "Tag search query"},
             data: {
-              controller: "tag-search-filter-focus",
-              action: "input->auto-submit-form#submit",
+              controller: "tag-search-filter-focus tag-search",
+              action: "input->auto-submit-form#submit " \
+                "keydown->tag-search#submitFirstResult",
               turbo_permanent: true
             },
             class: "w-full"
@@ -71,9 +72,11 @@
       </div>
     <% end %>
 
-    <%= render(Galleries::TagSearches::ResultsComponent.new(
-      tag_search: @tag_search,
-      mode: :gallery,
-    )) %>
+    <div data-tag-search-target="results">
+      <%= render(Galleries::TagSearches::ResultsComponent.new(
+        tag_search: @tag_search,
+        mode: :gallery,
+      )) %>
+    </div>
   <% end %>
 </div>

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -60,7 +60,7 @@
             autocomplete: "off",
             aria: {label: "Tag search query"},
             data: {
-              controller: "tag-search-filter-focus tag-search",
+              controller: "tag-search-filter-focus",
               action: "input->auto-submit-form#submit " \
                 "keydown->tag-search#submitFirstResult",
               turbo_permanent: true

--- a/spec/system/galleries/filtering_spec.rb
+++ b/spec/system/galleries/filtering_spec.rb
@@ -68,4 +68,19 @@ RSpec.describe "Gallery filtering" do
       "[aria-label='Tag search query']:focus"
     )
   end
+
+  it "preserves the query when pressing Enter with no results", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    login_as(user)
+
+    visit(gallery_path(gallery))
+
+    fill_in("Tag search query", with: "zzz")
+    expect(page).not_to have_css("[data-role=tag-search-result]")
+
+    find_field("Tag search query").send_keys(:enter)
+
+    expect(page).to have_field("Tag search query", with: "zzz")
+  end
 end

--- a/spec/system/galleries/filtering_spec.rb
+++ b/spec/system/galleries/filtering_spec.rb
@@ -37,4 +37,35 @@ RSpec.describe "Gallery filtering" do
     ).click
     expect(page).to have_css("[data-image-id='#{image.id}']")
   end
+
+  it "adds a filter when pressing Enter on a search result", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, :with_real_file, gallery:)
+    tag = create(:galleries_tag, gallery:, name: "alpha")
+    create(:galleries_tag, gallery:, name: "alpine")
+    image.add_tag(tag)
+    login_as(user)
+
+    visit(gallery_path(gallery))
+
+    fill_in("Tag search query", with: "alp")
+    click_on("Search")
+    expect(page).to have_css(
+      "[data-role=tag-search-result]",
+      text: tag.name
+    )
+
+    find_field("Tag search query").send_keys(:enter)
+
+    expect(page).to have_css(
+      "[data-role=tag-filter-remove-button]",
+      text: tag.name
+    )
+    expect(page).to have_css("[data-image-id='#{image.id}']")
+    expect(page).to have_field("Tag search query", with: "alp")
+    expect(page).to have_selector(
+      "[aria-label='Tag search query']:focus"
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- Gallery show page: pressing **Enter** in the tag search input with matching results now adds the first result's tag to the filter list (mirrors the image show page behavior). Focus and the typed query remain in the input.
- Wires the existing \`tag-search\` Stimulus controller into the filters partial.
- Extends the controller's \`submitFirstResult\` method to handle the gallery case: when the first result has no \`<form>\` (gallery results are links, not button_to forms), it clicks the \`[data-role="tag-search-result-add"]\` link. The image-page behavior (submit the result's form + restore query/focus through a \`turbo:before-stream-render\` hook) is preserved unchanged — the original logic was extracted into a private \`#submitResultForm\`.
- Adds two system specs: one for the Enter-adds-filter happy path, one pinning that Enter with no results preserves the query.