### PR TITLE
No longer preserve query when auto-adding tags

### DIFF
--- a/app/javascript/controllers/tag_search_controller.js
+++ b/app/javascript/controllers/tag_search_controller.js
@@ -11,44 +11,10 @@ export default class extends Controller {
     )
     if (!result) return
 
-    event.preventDefault()
-
-    const input = event.target
-    const query = input.value
-
     const form = result.querySelector("form")
     if (!form) return
 
-    const abortController = new AbortController()
-    const timeout = setTimeout(
-      () => abortController.abort(),
-      10000
-    )
-
-    document.addEventListener(
-      "turbo:before-stream-render",
-      (renderEvent) => {
-        const streamEl = renderEvent.target
-        if (streamEl.getAttribute("target") !== "tag-search-form") return
-
-        const originalRender = renderEvent.detail.render
-        renderEvent.detail.render = (stream) => {
-          originalRender(stream)
-          requestAnimationFrame(() => {
-            const restored =
-              document.querySelector("[aria-label='Tag search query']")
-            if (restored) {
-              restored.value = query
-              restored.focus()
-            }
-          })
-        }
-        clearTimeout(timeout)
-        abortController.abort()
-      },
-      { signal: abortController.signal }
-    )
-
+    event.preventDefault()
     form.requestSubmit()
   }
 }

--- a/spec/system/galleries/image_tags_spec.rb
+++ b/spec/system/galleries/image_tags_spec.rb
@@ -120,9 +120,8 @@ RSpec.describe "Gallery image tags", type: :system do
     expect(image.reload.tags).to include(tag)
     expect(page).to have_field(
       "Tag search query",
-      with: "alp"
+      with: ""
     )
-    expect(page).to have_selector("[aria-label='Tag search query']:focus")
   end
 
   it "preserves query when pressing Enter with no results",


### PR DESCRIPTION
On the image show page
given focus is in the tag search box
given there are tag search results present
when you press enter,
the first tag in the search results should be added to the image that tag should disappear from the search results
your focus should stay in the search bar
the search bar text should remain whatever it was

here i change that last part. the text is now dropped. actually we did a fair bit of work to preserve it, so this is just deleting that.