### PR TITLE
Clear bulk upload tag search when auto-adding tags

### DIFF
--- a/app/javascript/controllers/tag_search_controller.js
+++ b/app/javascript/controllers/tag_search_controller.js
@@ -15,6 +15,9 @@ export default class extends Controller {
     if (!form) return
 
     event.preventDefault()
+    const input = event.target
     form.requestSubmit()
+    input.value = ""
+    input.focus()
   }
 }

--- a/spec/system/galleries/bulk_uploads_spec.rb
+++ b/spec/system/galleries/bulk_uploads_spec.rb
@@ -132,4 +132,35 @@ RSpec.describe "Gallery bulk uploads",
       image.tags.pluck(:name)
     ).to include("landscapes")
   end
+
+  it "advances to the next tag on each Enter", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    create(:galleries_tag, name: "ruby-rails", gallery:)
+    create(:galleries_tag, name: "ruby-gem", gallery:)
+    login_as(user)
+
+    visit(new_gallery_bulk_upload_path(gallery))
+    fill_in("Tag search query", with: "rub")
+    wait_for_turbo
+    expect(page).to have_button("Add tag", count: 2)
+    find_field("Tag search query").send_keys(:enter)
+    wait_for_turbo
+
+    expect(find_field("Tag search query").value).to eq("")
+    expect(page).to have_css(
+      "input[aria-label='Tag search query']:focus"
+    )
+    expect(page).to have_selector(
+      "[data-role='tag']", count: 1
+    )
+    expect(page).to have_button("Add tag", count: 1)
+
+    find_field("Tag search query").send_keys(:enter)
+    wait_for_turbo
+
+    expect(page).to have_selector(
+      "[data-role='tag']", count: 2
+    )
+  end
 end


### PR DESCRIPTION
Pressing Enter in the bulk-upload tag search now clears the query and keeps focus on the input, so a second Enter adds the next remaining result without manual clearing.

This matches the flow already present in the image show page. 