### PR TITLE
Add notes to individual plant images

### DIFF
--- a/app/controllers/plants/plant_images_controller.rb
+++ b/app/controllers/plants/plant_images_controller.rb
@@ -78,7 +78,7 @@ module Plants
     end
 
     def plant_image_update_params
-      params.expect(plants_plant_image: [:taken_at])
+      params.expect(plants_plant_image: [:taken_at, :notes])
     end
   end
 end

--- a/app/models/plants/plant_image.rb
+++ b/app/models/plants/plant_image.rb
@@ -20,6 +20,7 @@
 module Plants
   class PlantImage < ApplicationRecord
     has_one_attached(:file)
+    has_rich_text(:notes)
 
     belongs_to(:plant)
 

--- a/app/views/plants/plant_images/edit.html.erb
+++ b/app/views/plants/plant_images/edit.html.erb
@@ -11,5 +11,6 @@
   method: :patch
 ) do |form| %>
   <%= form.input(:taken_at, as: :date, html5: true) %>
+  <%= form.rich_text_area(:notes) %>
   <%= form.button(:submit, "Update Image") %>
 <% end %>

--- a/app/views/plants/plant_images/show.html.erb
+++ b/app/views/plants/plant_images/show.html.erb
@@ -51,4 +51,13 @@
       <%= image_tag(@plant_image.file, class: "max-w-full h-auto") %>
     <% end %>
   </div>
+
+  <% if @plant_image.notes.present? %>
+    <div class="mt-8">
+      <h2 class="text-lg font-medium mb-2">Notes</h2>
+      <div class="prose prose-gray max-w-none">
+        <%= @plant_image.notes %>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/spec/models/plants/plant_image_spec.rb
+++ b/spec/models/plants/plant_image_spec.rb
@@ -21,6 +21,7 @@ require "rails_helper"
 
 RSpec.describe Plants::PlantImage do
   it { is_expected.to(belong_to(:plant)) }
+  it { is_expected.to(have_rich_text(:notes)) }
 
   it { is_expected.to(validate_presence_of(:file)) }
   it { is_expected.to(validate_presence_of(:taken_at)) }

--- a/spec/requests/plants/plant_images_controller_spec.rb
+++ b/spec/requests/plants/plant_images_controller_spec.rb
@@ -138,6 +138,23 @@ RSpec.describe "Plants::PlantImages", type: :request do
       expect(response.body).to(include(
         "Taken #{plant_image.taken_at.to_date.iso8601}"
       ))
+      expect(response.body).not_to(include("Notes"))
+    end
+
+    it "renders notes on show page when present" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      plant_image = create(
+        :plants_plant_image,
+        plant:,
+        notes: "yellowing on lower leaf"
+      )
+      login_as(user, scope: :user)
+
+      get(plant_plant_image_path(plant, plant_image))
+
+      expect(response).to(have_http_status(:ok))
+      expect(response.body).to(include("yellowing on lower leaf"))
     end
 
     it "errors when accessing another user's plant image" do
@@ -202,13 +219,32 @@ RSpec.describe "Plants::PlantImages", type: :request do
       login_as(user, scope: :user)
       params = {plants_plant_image: {taken_at: "2024-02-03"}}
 
-      patch(plant_plant_image_path(plant, plant_image), params: params)
+      patch(plant_plant_image_path(plant, plant_image), params:)
 
       expect(response).to(
         redirect_to(plant_plant_image_path(plant, plant_image))
       )
       expect(flash[:notice]).to(eq("Image was updated."))
       expect(plant_image.reload.taken_at.to_date).to(eq(Date.new(2024, 2, 3)))
+    end
+
+    it "updates the notes" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      plant_image = create(:plants_plant_image, plant:)
+      login_as(user, scope: :user)
+      params = {
+        plants_plant_image: {notes: "new growth visible"}
+      }
+
+      patch(plant_plant_image_path(plant, plant_image), params:)
+
+      expect(response).to(
+        redirect_to(plant_plant_image_path(plant, plant_image))
+      )
+      expect(plant_image.reload.notes.to_plain_text).to(
+        eq("new growth visible")
+      )
     end
 
     it "renders errors when taken_at is missing" do

--- a/spec/system/plants_spec.rb
+++ b/spec/system/plants_spec.rb
@@ -110,6 +110,35 @@ RSpec.describe "Plant management", type: :system do
     expect(page).to have_content("Taken 2024-02-03")
   end
 
+  it "adds and edits notes on a plant image", :js do
+    user = create(:user)
+    plant = create(:plant, user:)
+    plant_image = create(:plants_plant_image, plant:)
+    login_as(user)
+    visit(edit_plant_plant_image_path(plant, plant_image))
+
+    fill_in_rich_text_area(
+      "plants_plant_image_notes",
+      with: "yellowing on lower leaf"
+    )
+    click_button("Update Image")
+
+    expect(page).to have_content("Image was updated.")
+    expect(page).to have_content("Notes")
+    expect(page).to have_content("yellowing on lower leaf")
+
+    click_link("Edit")
+    fill_in_rich_text_area(
+      "plants_plant_image_notes",
+      with: "leaf recovered"
+    )
+    click_button("Update Image")
+
+    expect(page).to have_content("Image was updated.")
+    expect(page).to have_content("leaf recovered")
+    expect(page).not_to have_content("yellowing on lower leaf")
+  end
+
   it "sets the key image from the image show page" do
     user = create(:user)
     plant = create(:plant, user:)


### PR DESCRIPTION
Lets users record observations tied to a specific photo (e.g. "yellowing on lower leaf") so they can track plant changes over time. Notes are rich text via ActionText, settable on upload and edit, and rendered on the image's show page only — the gallery grid stays clean.