### PR TITLE
Close bulk-tag dialog on submit to avoid stuck modal state

### DIFF
--- a/app/views/galleries/show.html.erb
+++ b/app/views/galleries/show.html.erb
@@ -165,7 +165,8 @@
             @gallery,
             **request.query_parameters
           ),
-          method: :post
+          method: :post,
+          data: {action: "submit->dialog#close"}
         ) do |f| %>
           <div data-gallery-bulk-tag-target="selectedIdsContainer"></div>
           <%= f.hidden_field(

--- a/spec/system/galleries/select_mode_spec.rb
+++ b/spec/system/galleries/select_mode_spec.rb
@@ -174,6 +174,45 @@ RSpec.describe "Gallery select mode" do
     expect(image.reload.tags).to include(tag)
   end
 
+  it "keeps header buttons responsive after two consecutive bulk " \
+    "tags", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    tag1 = create(:galleries_tag, gallery:, name: "nature")
+    tag2 = create(:galleries_tag, gallery:, name: "people")
+    image = create(:galleries_image, :with_real_file, gallery:)
+    login_as(user)
+
+    visit(gallery_path(gallery, select: true))
+
+    find("[data-image-id='#{image.id}']").click
+
+    click_on("Add tag")
+    within(find("dialog[open]")) do
+      fill_in("tag_search[query]", with: "nat")
+      within("[data-role=tag-search-result]", text: tag1.display_name) do
+        click_on("Select")
+      end
+      click_button("Add tag")
+    end
+    expect(page).to have_text("Tag added to selected images")
+
+    click_on("Add tag")
+    within(find("dialog[open]")) do
+      fill_in("tag_search[query]", with: "peo")
+      within("[data-role=tag-search-result]", text: tag2.display_name) do
+        click_on("Select")
+      end
+      click_button("Add tag")
+    end
+    expect(page).to have_text("Tag added to selected images")
+
+    expect(page).to have_no_css("dialog[open]")
+
+    click_on("Add tag")
+    expect(page).to have_css("dialog[open]")
+  end
+
   it "preserves selection after bulk tagging", :js do
     user = create(:user)
     gallery = create(:gallery, user:)


### PR DESCRIPTION
## Summary
- Bulk-adding tags twice in a row left the gallery page stuck: the header `Add tag` and `Cancel` buttons stopped responding to clicks until refresh.
- Root cause: the layout uses `turbo-refresh-method=morph`, so `BulkTagsController#create`'s `redirect_to(gallery_path(...))` morphs the open `<dialog>` in place. Morph removed the `open` attribute, but the browser doesn't treat that as "closed" — only `dialog.close()` pops it from the top layer. The dialog stayed invisibly modal and intercepted clicks on `<html>` (Playwright spelled this out: `<html>…</html> intercepts pointer events`).
- Fix: `data-action="submit->dialog#close"` on the bulk-tag form so the dialog leaves the top layer cleanly before Turbo morphs.

## Test plan
- [x] New `:js` system spec performs two consecutive bulk-tag operations and asserts the header `Add tag` button still opens the dialog. Fails on `main`, passes with this change.
- [x] `bin/rspec spec/system/galleries/` (42 examples) — green
- [x] `bin/rspec spec/requests/galleries/bulk_tags_controller_spec.rb spec/components/galleries/tag_search_dialog_component_spec.rb` — green
- [x] `bin/standardrb` — clean