### PR TITLE
Refresh recent tags via lazy turbo-frame

### DIFF
--- a/app/components/galleries/image_tag_search_component.rb
+++ b/app/components/galleries/image_tag_search_component.rb
@@ -14,23 +14,11 @@ module Galleries
           )) %>
         </div>
 
-        <h4 class="text-xl mt-10">Recently used tags</h4>
-        <% grouped_tags.each_with_index do |(image_id, results), index| %>
-          <% if index > 0 %>
-            <hr class="my-4 border-gray-300" data-testid="tag-group-separator">
-          <% end %>
-          <div class="flex flex-wrap gap-2 my-2">
-            <% results.each do |result| %>
-              <%= turbo_frame_tag("recently-added-tag-\#{result.tag.id}") do %>
-                <%= button_to(
-                  result.tag.display_name,
-                  gallery_image_tags_path(@gallery, @image, tag_id: result.tag.id),
-                  class: "button"
-                ) %>
-              <% end %>
-            <% end %>
-          </div>
-        <% end %>
+        <%= turbo_frame_tag(
+          "image-recent-tags",
+          src: gallery_image_recent_tags_path(@gallery, @image),
+          loading: :lazy
+        ) %>
       </div>
     ERB
 
@@ -38,14 +26,6 @@ module Galleries
       @tag_search = tag_search
       @gallery = tag_search.gallery
       @image = tag_search.image
-    end
-
-    private
-
-    def grouped_tags
-      @gallery
-        .recently_used_tags(excluded_image_ids: [@image.id])
-        .group_by(&:most_recent_image_id)
     end
   end
 end

--- a/app/components/galleries/images/recent_tags_component.rb
+++ b/app/components/galleries/images/recent_tags_component.rb
@@ -1,0 +1,38 @@
+module Galleries
+  module Images
+    class RecentTagsComponent < ApplicationComponent
+      erb_template <<~ERB
+        <h4 class="text-xl mt-10">Recently used tags</h4>
+        <% grouped_tags.each_with_index do |(image_id, results), index| %>
+          <% if index > 0 %>
+            <hr class="my-4 border-gray-300" data-testid="tag-group-separator">
+          <% end %>
+          <div class="flex flex-wrap gap-2 my-2">
+            <% results.each do |result| %>
+              <%= turbo_frame_tag("recently-added-tag-\#{result.tag.id}") do %>
+                <%= button_to(
+                  result.tag.display_name,
+                  gallery_image_tags_path(@gallery, @image, tag_id: result.tag.id),
+                  class: "button"
+                ) %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      ERB
+
+      def initialize(gallery:, image:)
+        @gallery = gallery
+        @image = image
+      end
+
+      private
+
+      def grouped_tags
+        @gallery
+          .recently_used_tags(excluded_image_ids: [@image.id])
+          .group_by(&:most_recent_image_id)
+      end
+    end
+  end
+end

--- a/app/components/galleries/images/recent_tags_component.rb
+++ b/app/components/galleries/images/recent_tags_component.rb
@@ -2,22 +2,24 @@ module Galleries
   module Images
     class RecentTagsComponent < ApplicationComponent
       erb_template <<~ERB
-        <h4 class="text-xl mt-10">Recently used tags</h4>
-        <% grouped_tags.each_with_index do |(image_id, results), index| %>
-          <% if index > 0 %>
-            <hr class="my-4 border-gray-300" data-testid="tag-group-separator">
-          <% end %>
-          <div class="flex flex-wrap gap-2 my-2">
-            <% results.each do |result| %>
-              <%= turbo_frame_tag("recently-added-tag-\#{result.tag.id}") do %>
-                <%= button_to(
-                  result.tag.display_name,
-                  gallery_image_tags_path(@gallery, @image, tag_id: result.tag.id),
-                  class: "button"
-                ) %>
-              <% end %>
+        <%= turbo_frame_tag("image-recent-tags") do %>
+          <h4 class="text-xl mt-10">Recently used tags</h4>
+          <% grouped_tags.each_with_index do |(image_id, results), index| %>
+            <% if index > 0 %>
+              <hr class="my-4 border-gray-300" data-testid="tag-group-separator">
             <% end %>
-          </div>
+            <div class="flex flex-wrap gap-2 my-2">
+              <% results.each do |result| %>
+                <%= turbo_frame_tag("recently-added-tag-\#{result.tag.id}") do %>
+                  <%= button_to(
+                    result.tag.display_name,
+                    gallery_image_tags_path(@gallery, @image, tag_id: result.tag.id),
+                    class: "button"
+                  ) %>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
         <% end %>
       ERB
 

--- a/app/controllers/galleries/images/recent_tags_controller.rb
+++ b/app/controllers/galleries/images/recent_tags_controller.rb
@@ -1,0 +1,24 @@
+module Galleries
+  module Images
+    class RecentTagsController < ApplicationController
+      before_action :ensure_authenticated!
+      after_action :verify_authorized
+
+      def show
+        @gallery = find_gallery
+        @image = find_image
+        authorize(@gallery, :show?)
+      end
+
+      private
+
+      def find_gallery
+        policy_scope(Gallery).find(params[:gallery_id])
+      end
+
+      def find_image
+        policy_scope(Galleries::Image).where(gallery: @gallery).find(params[:image_id])
+      end
+    end
+  end
+end

--- a/app/controllers/galleries/images/recent_tags_controller.rb
+++ b/app/controllers/galleries/images/recent_tags_controller.rb
@@ -8,6 +8,13 @@ module Galleries
         @gallery = find_gallery
         @image = find_image
         authorize(@gallery, :show?)
+
+        html =
+          Galleries::Images::RecentTagsComponent
+            .new(gallery: @gallery, image: @image)
+            .render_in(view_context)
+
+        render(html:)
       end
 
       private

--- a/app/views/galleries/images/recent_tags/show.html.erb
+++ b/app/views/galleries/images/recent_tags/show.html.erb
@@ -1,6 +1,0 @@
-<%= turbo_frame_tag "image-recent-tags" do %>
-  <%= render(Galleries::Images::RecentTagsComponent.new(
-    gallery: @gallery,
-    image: @image
-  )) %>
-<% end %>

--- a/app/views/galleries/images/recent_tags/show.html.erb
+++ b/app/views/galleries/images/recent_tags/show.html.erb
@@ -1,0 +1,6 @@
+<%= turbo_frame_tag "image-recent-tags" do %>
+  <%= render(Galleries::Images::RecentTagsComponent.new(
+    gallery: @gallery,
+    image: @image
+  )) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       resources :images, except: %i[new create] do
         resources :tags, only: %i[create destroy], module: :images
         resource :tag_search, only: %i[show], module: :images
+        resource :recent_tags, only: %i[show], module: :images
         resources :book_images, only: %i[new create], module: :images
       end
       resource :bulk_upload, only: %i[new create] do

--- a/spec/components/galleries/image_tag_search_component_spec.rb
+++ b/spec/components/galleries/image_tag_search_component_spec.rb
@@ -25,5 +25,6 @@ RSpec.describe Galleries::ImageTagSearchComponent, type: :component do
       "[src='#{expected_src}']" \
       "[loading='lazy']"
     )
+    expect(page).to have_no_css("h4", text: "Recently used tags")
   end
 end

--- a/spec/components/galleries/image_tag_search_component_spec.rb
+++ b/spec/components/galleries/image_tag_search_component_spec.rb
@@ -12,34 +12,18 @@ RSpec.describe Galleries::ImageTagSearchComponent, type: :component do
     )
   end
 
-  it "includes recently used tags" do
-    tag_search = create(:galleries_tag_search, :with_image)
-    gallery = tag_search.gallery
-    other_image = create(:galleries_image, gallery:)
-    tag = create(:galleries_tag, gallery:)
-    other_image.add_tag(tag)
+  it "renders a lazy turbo-frame pointing at the recent_tags endpoint" do
+    tag_search = build_stubbed(:galleries_tag_search, :with_image)
     component = described_class.new(tag_search:)
+
     render_inline(component)
 
-    expect(page).to have_css("h4", text: "Recently used tags")
-    expect(page).to have_button(tag.reload.display_name)
-  end
-
-  it "groups tags by image with separators" do
-    tag_search = create(:galleries_tag_search, :with_image)
-    gallery = tag_search.gallery
-    image1, image2 = create_pair(:galleries_image, gallery:)
-    tag1, tag2 = create_pair(:galleries_tag, gallery:)
-    tag3 = create(:galleries_tag, gallery:)
-    image1.add_tag(tag1)
-    image1.add_tag(tag2)
-    image2.add_tag(tag3)
-    component = described_class.new(tag_search:)
-    render_inline(component)
-
-    expect(page).to have_css("[data-testid='tag-group-separator']", count: 1)
-    expect(page).to have_text(tag1.reload.display_name)
-    expect(page).to have_text(tag2.reload.display_name)
-    expect(page).to have_text(tag3.reload.display_name)
+    expected_src = Rails.application.routes.url_helpers
+      .gallery_image_recent_tags_path(tag_search.gallery, tag_search.image)
+    expect(page).to have_css(
+      "turbo-frame#image-recent-tags" \
+      "[src='#{expected_src}']" \
+      "[loading='lazy']"
+    )
   end
 end

--- a/spec/components/galleries/images/recent_tags_component_spec.rb
+++ b/spec/components/galleries/images/recent_tags_component_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Galleries::Images::RecentTagsComponent, type: :component do
+  it "renders a button for each recently used tag" do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    other_image = create(:galleries_image, gallery:)
+    tag = create(:galleries_tag, gallery:, name: "rose")
+    other_image.add_tag(tag)
+
+    render_inline(described_class.new(gallery:, image:))
+
+    expect(page).to have_css("h4", text: "Recently used tags")
+    expect(page).to have_button(tag.reload.display_name)
+  end
+
+  it "excludes tags that are already on the current image" do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    tag = create(:galleries_tag, gallery:, name: "tulip")
+    image.add_tag(tag)
+
+    render_inline(described_class.new(gallery:, image:))
+
+    expect(page).to have_no_button(tag.reload.display_name)
+  end
+
+  it "groups tags by image with separators" do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    image1, image2 = create_pair(:galleries_image, gallery:)
+    tag1, tag2 = create_pair(:galleries_tag, gallery:)
+    tag3 = create(:galleries_tag, gallery:)
+    image1.add_tag(tag1)
+    image1.add_tag(tag2)
+    image2.add_tag(tag3)
+
+    render_inline(described_class.new(gallery:, image:))
+
+    expect(page).to have_css("[data-testid='tag-group-separator']", count: 1)
+    expect(page).to have_text(tag1.reload.display_name)
+    expect(page).to have_text(tag2.reload.display_name)
+    expect(page).to have_text(tag3.reload.display_name)
+  end
+end

--- a/spec/components/galleries/images/recent_tags_component_spec.rb
+++ b/spec/components/galleries/images/recent_tags_component_spec.rb
@@ -18,19 +18,35 @@ RSpec.describe Galleries::Images::RecentTagsComponent, type: :component do
   it "excludes tags that are already on the current image" do
     user = create(:user)
     gallery = create(:gallery, user:)
+    current_image = create(:galleries_image, gallery:)
+    other_image = create(:galleries_image, gallery:)
+    excluded = create(:galleries_tag, gallery:, name: "tulip")
+    visible = create(:galleries_tag, gallery:, name: "daisy")
+    current_image.add_tag(excluded)
+    other_image.add_tag(visible)
+
+    render_inline(described_class.new(gallery:, image: current_image))
+
+    expect(page).to have_button(visible.reload.display_name)
+    expect(page).to have_no_button(excluded.reload.display_name)
+  end
+
+  it "renders only the heading when there are no recent tags" do
+    user = create(:user)
+    gallery = create(:gallery, user:)
     image = create(:galleries_image, gallery:)
-    tag = create(:galleries_tag, gallery:, name: "tulip")
-    image.add_tag(tag)
 
     render_inline(described_class.new(gallery:, image:))
 
-    expect(page).to have_no_button(tag.reload.display_name)
+    expect(page).to have_css("h4", text: "Recently used tags")
+    expect(page).to have_no_css("button")
+    expect(page).to have_no_css("[data-testid='tag-group-separator']")
   end
 
   it "groups tags by image with separators" do
     user = create(:user)
     gallery = create(:gallery, user:)
-    image = create(:galleries_image, gallery:)
+    current_image = create(:galleries_image, gallery:)
     image1, image2 = create_pair(:galleries_image, gallery:)
     tag1, tag2 = create_pair(:galleries_tag, gallery:)
     tag3 = create(:galleries_tag, gallery:)
@@ -38,11 +54,11 @@ RSpec.describe Galleries::Images::RecentTagsComponent, type: :component do
     image1.add_tag(tag2)
     image2.add_tag(tag3)
 
-    render_inline(described_class.new(gallery:, image:))
+    render_inline(described_class.new(gallery:, image: current_image))
 
     expect(page).to have_css("[data-testid='tag-group-separator']", count: 1)
-    expect(page).to have_text(tag1.reload.display_name)
-    expect(page).to have_text(tag2.reload.display_name)
-    expect(page).to have_text(tag3.reload.display_name)
+    expect(page).to have_button(tag1.reload.display_name)
+    expect(page).to have_button(tag2.reload.display_name)
+    expect(page).to have_button(tag3.reload.display_name)
   end
 end

--- a/spec/requests/galleries/images/recent_tags_controller_spec.rb
+++ b/spec/requests/galleries/images/recent_tags_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Galleries::Images::RecentTagsController do
+  describe "show" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+
+      get(gallery_image_recent_tags_path(gallery, image))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when the gallery is not owned by the current user" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+      other_user = create(:user)
+      login_as(other_user)
+
+      get(gallery_image_recent_tags_path(gallery, image))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renders the recent tags inside an image-recent-tags turbo-frame" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      other_image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:, name: "daisy")
+      other_image.add_tag(tag)
+      login_as(user)
+
+      get(gallery_image_recent_tags_path(gallery, image))
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_css("turbo-frame#image-recent-tags")
+      expect(page).to have_button(tag.reload.display_name)
+    end
+  end
+end

--- a/spec/requests/galleries/images/recent_tags_controller_spec.rb
+++ b/spec/requests/galleries/images/recent_tags_controller_spec.rb
@@ -22,6 +22,18 @@ RSpec.describe Galleries::Images::RecentTagsController do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "returns 404 when the image belongs to a different gallery" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      other_gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery: other_gallery)
+      login_as(user)
+
+      get(gallery_image_recent_tags_path(gallery, image))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
     it "renders the recent tags inside an image-recent-tags turbo-frame" do
       user = create(:user)
       gallery = create(:gallery, user:)
@@ -36,6 +48,19 @@ RSpec.describe Galleries::Images::RecentTagsController do
       expect(response).to have_http_status(:ok)
       expect(page).to have_css("turbo-frame#image-recent-tags")
       expect(page).to have_button(tag.reload.display_name)
+    end
+
+    it "renders an empty turbo-frame when no other images carry tags" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      login_as(user)
+
+      get(gallery_image_recent_tags_path(gallery, image))
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_css("turbo-frame#image-recent-tags")
+      expect(page).to have_no_css("button")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Extract the recent-tags markup from `Galleries::ImageTagSearchComponent` into a new `Galleries::Images::RecentTagsComponent`.
- Add `Galleries::Images::RecentTagsController#show` and render the new component inside `<turbo-frame id="image-recent-tags">`.
- Replace the inline render on the image show page with a lazy `<turbo-frame src=… loading="lazy">`. Each visit to the page now fetches a fresh recent-tags list instead of the snapshot rendered server-side at initial load.

This is v1 (lazy-load only) of [Refresh tags on page load](https://www.notion.so/35b29975146180d28250f451b90d2b82). A follow-up may add a `visibilitychange` Stimulus controller so already-loaded backgrounded tabs also refresh on focus.

## Test plan
- [x] Component spec for `Galleries::Images::RecentTagsComponent` (renders, excludes current-image tags, groups by image with separators)
- [x] Request spec for `Galleries::Images::RecentTagsController#show` (auth, 404, happy path)
- [x] Updated `Galleries::ImageTagSearchComponent` spec asserts the lazy turbo-frame attributes
- [x] Full suite: 1059 examples, 0 failures
- [x] `standardrb --fix` clean
- [ ] Manual: visit image show page, observe single `recent_tags` request in DevTools, confirm tags render and click-to-add still works