### PR TITLE
Use TagPillComponent for active gallery tag filters

### DIFF
--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -92,6 +92,6 @@ class GalleriesController < ApplicationController
 
   def find_filter_tags
     ids = params.fetch(:tag_ids, [])
-    @gallery.tags.where(id: ids)
+    @gallery.tags.where(id: ids).each { it.gallery = @gallery }
   end
 end

--- a/app/views/galleries/_filters.html.erb
+++ b/app/views/galleries/_filters.html.erb
@@ -3,24 +3,25 @@
 
   <div class="flex mb-4 gap-2 flex-wrap">
     <% @filter_tags.each do |tag| %>
-      <%= link_to(
-        url_for(
-          tag_ids: params.fetch(:tag_ids, []) - [tag.id.to_s],
-          tag_search: {query: @tag_search.query},
-          select: @select_mode ? "true" : nil,
-          selected_ids: @selected_ids,
-          page: params[:page]
-        ),
-        class: "bg-gray-200 rounded-full px-4 py-2",
-        data: {
-          turbo: false,
-          role: "tag-filter-remove-button",
-        }
-      ) do %>
-        <span>×</span>
-        <span class="font-bold">
-          <%= tag.name %>
-        </span>
+      <%= render(Galleries::TagPillComponent.new(tag:)) do |c| %>
+        <% c.with_action do %>
+          <%= link_to(
+            "×",
+            url_for(
+              tag_ids: params.fetch(:tag_ids, []) - [tag.id.to_s],
+              tag_search: {query: @tag_search.query},
+              select: @select_mode ? "true" : nil,
+              selected_ids: @selected_ids,
+              page: params[:page]
+            ),
+            aria: {label: "Remove #{tag.name} filter"},
+            class: "opacity-60 hover:opacity-100",
+            data: {
+              turbo: false,
+              role: "tag-filter-remove-button"
+            }
+          ) %>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/spec/requests/galleries_spec.rb
+++ b/spec/requests/galleries_spec.rb
@@ -133,6 +133,24 @@ RSpec.describe GalleriesController do
 
       expect(response).to redirect_to(new_session_path)
     end
+
+    it "renders filter tag pill with classification color" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      tag = create(
+        :galleries_tag,
+        gallery:,
+        classification: :subject
+      )
+      login_as(user)
+
+      get(gallery_path(gallery, tag_ids: [tag.id]))
+
+      expect(page).to have_css(
+        "span.bg-purple-100.text-purple-800",
+        text: tag.display_name
+      )
+    end
   end
 
   describe "update" do

--- a/spec/system/galleries/filtering_spec.rb
+++ b/spec/system/galleries/filtering_spec.rb
@@ -23,18 +23,14 @@ RSpec.describe "Gallery filtering" do
     )
     expect(page).to have_css("[data-image-id='#{image.id}']")
     expect(page).to have_css(
-      "[data-role=tag-filter-remove-button]",
-      text: tag.name
+      "[aria-label='Remove #{tag.name} filter']"
     )
     expect(page).to have_field("Tag search query", with: tag.name)
     expect(page).to have_selector(
       "[aria-label='Tag search query']:focus"
     )
 
-    find(
-      "[data-role=tag-filter-remove-button]",
-      text: tag.name
-    ).click
+    find("[aria-label='Remove #{tag.name} filter']").click
     expect(page).to have_css("[data-image-id='#{image.id}']")
   end
 end


### PR DESCRIPTION
## Summary
- Active tag filter pills on the gallery show page now use `Galleries::TagPillComponent`, so they take on the tag's classification color (subject/system/artist/none) instead of always rendering gray.
- The remove (`×`) action moves into the pill via the component's `actions` slot, with an `aria-label='Remove <name> filter'` for accessibility and the existing `data-role='tag-filter-remove-button'` preserved.
- Preset `tag.gallery = @gallery` in `find_filter_tags` to avoid an N+1 introduced by the component's per-tag link to `gallery_tag_path`.

Resolves: https://www.notion.so/jutonz/Tag-filters-don-t-use-right-colors-33629975146180d08688c611b494fa43

## Test plan
- [x] `bin/rspec spec/requests/galleries_spec.rb` (added coverage for filter pill classification color)
- [x] `bin/rspec spec/system/galleries/filtering_spec.rb` (updated to find the `×` link by aria-label)
- [x] `bin/rspec spec/requests/galleries spec/system/galleries spec/components/galleries` (271 examples, 0 failures)