### PR TITLE
Add bin/worktree-setup + auto-run hook for fresh worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "EnterWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bin/worktree-setup",
+            "timeout": 180,
+            "statusMessage": "Preparing worktree (keys + assets)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/bin/worktree-setup
+++ b/bin/worktree-setup
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Prepare a fresh git worktree.
+#
+# A fresh worktree is missing two gitignored things it needs:
+#   - per-environment credential keys (config/credentials/*.key)
+#   - compiled assets (tailwind.css, etc.)
+# Gems and the database are shared across worktrees, so `bundle install`
+# and `db:prepare` are not needed. This copies the keys from the main
+# checkout (no 1Password prompt, unlike bin/setup) and builds assets.
+#
+# Idempotent. No-op when run outside a linked worktree.
+set -euo pipefail
+
+git_dir="$(cd "$(git rev-parse --git-dir)" && pwd -P)"
+common_dir="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+
+if [ "$git_dir" = "$common_dir" ]; then
+  echo "Not in a linked worktree; nothing to do."
+  exit 0
+fi
+
+main_root="$(dirname "$common_dir")"
+
+echo "Copying credential keys from $main_root"
+for env in development test production; do
+  cp "$main_root/config/credentials/$env.key" \
+    "config/credentials/$env.key"
+done
+
+echo "Precompiling assets"
+mise exec -- bin/rails assets:precompile >/dev/null 2>&1
+
+echo "Worktree ready"


### PR DESCRIPTION
Fresh worktrees lack gitignored credential keys and compiled assets, so `bin/rspec` fails. Adds `bin/worktree-setup` (copies the keys from the main checkout — no 1Password prompt — and precompiles assets; gems and the test DB are shared across worktrees, so `bundle install`/`db:prepare` aren't needed) and a `PostToolUse`/`EnterWorktree` hook in `.claude/settings.json` that runs it automatically.