### PR TITLE
Better video thumbnails on mobile

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - run: sudo apt-get update && sudo apt-get install imagemagick libvips
+      - run: sudo apt-get update && sudo apt-get install imagemagick libvips ffmpeg
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:
@@ -59,7 +59,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - run: sudo apt-get update && sudo apt-get install imagemagick libvips
+      - run: sudo apt-get update && sudo apt-get install imagemagick libvips ffmpeg
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `mise exec -- bin/rails db:migrate` - Run database migrations
 - `mise exec -- bin/rails g migration AddExampleMigration` - Create a new
   database migration
-- Install `ffmpeg` (system binary, not a gem) — required to generate
-  video poster thumbnails. macOS: `brew install ffmpeg`. Linux/CI:
-  `apt-get install -y ffmpeg`.
 ### Testing & Quality
 - `mise exec -- bin/rspec` - Run RSpec test suite
 - `mise exec -- bin/standardrb --fix` - Ruby linting and code style (Standard gem)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `mise exec -- bin/rails db:migrate` - Run database migrations
 - `mise exec -- bin/rails g migration AddExampleMigration` - Create a new
   database migration
+- Install `ffmpeg` (system binary, not a gem) — required to generate
+  video poster thumbnails. macOS: `brew install ffmpeg`. Linux/CI:
+  `apt-get install -y ffmpeg`.
 ### Testing & Quality
 - `mise exec -- bin/rspec` - Run RSpec test suite
 - `mise exec -- bin/standardrb --fix` - Ruby linting and code style (Standard gem)

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM base
 
 # Install packages needed for deployment
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client imagemagick && \
+    apt-get install --no-install-recommends -y curl libvips postgresql-client imagemagick ffmpeg && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Copy built artifacts: gems, application

--- a/app/components/galleries/image_thumbnail_component.rb
+++ b/app/components/galleries/image_thumbnail_component.rb
@@ -14,7 +14,28 @@ module Galleries
       ) do %>
         <div class="flex justify-center">
           <% if @image.video? %>
-            <%= video_tag(@image.file, preload: "metadata") %>
+            <div class="relative" data-role="video-thumbnail">
+              <%= image_tag(@image.poster) %>
+              <span
+                data-role="video-overlay"
+                class="absolute inset-0 flex items-center
+                       justify-center"
+              >
+                <span
+                  class="flex items-center justify-center w-12 h-12
+                         rounded-full bg-black/50"
+                >
+                  <svg
+                    class="w-6 h-6 text-white"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path d="M8 5v14l11-7z" />
+                  </svg>
+                </span>
+              </span>
+            </div>
           <% elsif @image.file.variable? %>
             <%= image_tag(@image.file.variant(:thumb)) %>
           <% else %>

--- a/app/jobs/galleries/image_processing_job.rb
+++ b/app/jobs/galleries/image_processing_job.rb
@@ -5,6 +5,8 @@ module Galleries
     def perform(image)
       if image.file.variable?
         image.file.variant(:thumb).processed
+      elsif image.file.previewable?
+        image.poster.processed
       end
 
       image.calculate_perceptual_hash!

--- a/app/models/galleries/image.rb
+++ b/app/models/galleries/image.rb
@@ -87,6 +87,8 @@ module Galleries
 
     def video? = file.content_type.start_with?("video/")
 
+    def poster = file.preview(resize_to_limit: [200, 200])
+
     def calculate_perceptual_hash!
       return if video?
 

--- a/app/models/galleries/image.rb
+++ b/app/models/galleries/image.rb
@@ -20,8 +20,11 @@
 #
 module Galleries
   class Image < ActiveRecord::Base
+    THUMB_SIZE = [200, 200].freeze
+    VIDEO_CONTENT_TYPE_PREFIX = "video/"
+
     has_one_attached :file do |file|
-      file.variant(:thumb, resize_to_limit: [200, 200])
+      file.variant(:thumb, resize_to_limit: THUMB_SIZE)
     end
 
     belongs_to :gallery, counter_cache: true
@@ -41,6 +44,14 @@ module Galleries
     def self.unprocessed = where(processed_at: nil)
 
     def self.processed = where.not(processed_at: nil)
+
+    def self.videos
+      joins(file_attachment: :blob)
+        .where(
+          "active_storage_blobs.content_type LIKE ?",
+          "#{VIDEO_CONTENT_TYPE_PREFIX}%"
+        )
+    end
 
     def self.by_tags(tag_ids)
       joins(:tags)
@@ -85,9 +96,9 @@ module Galleries
       image_tags.where(tag:).destroy_all
     end
 
-    def video? = file.content_type.start_with?("video/")
+    def video? = file.content_type.start_with?(VIDEO_CONTENT_TYPE_PREFIX)
 
-    def poster = file.preview(resize_to_limit: [200, 200])
+    def poster = file.preview(resize_to_limit: THUMB_SIZE)
 
     def calculate_perceptual_hash!
       return if video?

--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,7 @@ FileUtils.chdir APP_ROOT do
     exit
   end
 
-  brew_deps = %w[imagemagick vips]
+  brew_deps = %w[imagemagick vips ffmpeg]
   begin
     system!("command -v brew > /dev/null")
     system!("brew install #{brew_deps.join(" ")}")

--- a/lib/tasks/deployment/20260516120000_backfill_video_posters.rake
+++ b/lib/tasks/deployment/20260516120000_backfill_video_posters.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc "Deployment task: backfill_video_posters"
+  task backfill_video_posters: :environment do
+    puts "Running deploy task 'backfill_video_posters'"
+
+    Galleries::Image
+      .joins(file_attachment: :blob)
+      .where("active_storage_blobs.content_type LIKE ?", "video/%")
+      .in_batches do |batch|
+        batch
+          .map { Galleries::ImageProcessingJob.new(it) }
+          .then { ActiveJob.perform_all_later(it) }
+      end
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20260516120000_backfill_video_posters.rake
+++ b/lib/tasks/deployment/20260516120000_backfill_video_posters.rake
@@ -4,14 +4,15 @@ namespace :after_party do
     puts "Running deploy task 'backfill_video_posters'"
 
     Galleries::Image
-      .joins(file_attachment: :blob)
-      .where("active_storage_blobs.content_type LIKE ?", "video/%")
+      .videos
       .in_batches do |batch|
         batch
           .map { Galleries::ImageProcessingJob.new(it) }
           .then { ActiveJob.perform_all_later(it) }
       end
 
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
     AfterParty::TaskRecord
       .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
   end

--- a/spec/components/galleries/image_thumbnail_component_spec.rb
+++ b/spec/components/galleries/image_thumbnail_component_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe Galleries::ImageThumbnailComponent, type: :component do
     )
   end
 
-  it "displays thumbnails for videos" do
+  it "renders a poster image with a play overlay for videos" do
     image = create(:galleries_image, :webm)
     component = described_class.new(image:)
+
     render_inline(component)
 
-    expect(page).to have_css(
-      "video[preload=metadata]"
-    )
+    expect(page).to have_css("img")
+    expect(page).to have_css("[data-role=video-overlay]")
+    expect(page).not_to have_css("video")
   end
 end

--- a/spec/jobs/galleries/image_processing_job_spec.rb
+++ b/spec/jobs/galleries/image_processing_job_spec.rb
@@ -54,4 +54,14 @@ RSpec.describe Galleries::ImageProcessingJob, "#perform" do
           "processing_image_#{image.id}"
       )
   end
+
+  it "processes a poster preview for previewable (video) files" do
+    image = create(:galleries_image, :webm)
+    poster = instance_double(ActiveStorage::Preview)
+    allow(image).to receive(:poster).and_return(poster)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_remove_to)
+    expect(poster).to receive(:processed)
+
+    described_class.new.perform(image)
+  end
 end

--- a/spec/lib/tasks/deployment/backfill_video_posters_spec.rb
+++ b/spec/lib/tasks/deployment/backfill_video_posters_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "rake"
+
+unless Rake::Task.task_defined?("after_party:backfill_video_posters")
+  Rails.application.load_tasks
+end
+
+RSpec.describe "after_party:backfill_video_posters" do
+  it "enqueues ImageProcessingJob only for video images" do
+    video = create(:galleries_image, :webm)
+    non_video = create(:galleries_image)
+    task = Rake::Task["after_party:backfill_video_posters"]
+    task.reenable
+
+    task.invoke
+
+    expect(Galleries::ImageProcessingJob)
+      .to have_been_enqueued.with(video)
+    expect(Galleries::ImageProcessingJob)
+      .not_to have_been_enqueued.with(non_video)
+  end
+end

--- a/spec/models/galleries/image_spec.rb
+++ b/spec/models/galleries/image_spec.rb
@@ -191,6 +191,15 @@ RSpec.describe Galleries::Image do
         resize_to_limit: [200, 200]
       )
     end
+
+    it "extracts a real non-empty video frame when processed" do
+      image = create(:galleries_image, :webm)
+
+      processed = image.poster.processed
+
+      expect(processed.image.attached?).to be(true)
+      expect(processed.image.blob.byte_size).to be > 0
+    end
   end
 
   describe "#calculate_perceptual_hash!" do

--- a/spec/models/galleries/image_spec.rb
+++ b/spec/models/galleries/image_spec.rb
@@ -180,6 +180,19 @@ RSpec.describe Galleries::Image do
     end
   end
 
+  describe "#poster" do
+    it "returns a 200x200-limited Active Storage preview of the video" do
+      image = create(:galleries_image, :webm)
+
+      poster = image.poster
+
+      expect(poster).to be_a(ActiveStorage::Preview)
+      expect(poster.variation.transformations).to eq(
+        resize_to_limit: [200, 200]
+      )
+    end
+  end
+
   describe "#calculate_perceptual_hash!" do
     it "calculates and saves a perceptual_hash" do
       image = create(:galleries_image, :with_real_file, perceptual_hash: nil)


### PR DESCRIPTION
## Summary

Renders gallery-grid videos as their real first-frame still image with a centered play-icon overlay, instead of a blank `<video>` box on iOS Safari. Tapping still navigates to the unchanged single-image detail page where `<video controls>` plays. No schema change, no new attachment — the poster is an Active Storage representation of the existing `file` blob.

Notion: [Better video thumbnails on mobile](https://www.notion.so/2a529975146180fc8466eee471ea2434)

## Approach

`Galleries::Image#poster` → `file.preview(resize_to_limit: THUMB_SIZE)` (same size as the `:thumb` variant). Generated eagerly in `Galleries::ImageProcessingJob` (new `previewable?` branch), backfilled for existing videos via an `after_party` deployment task (`Galleries::Image.videos` scope + bulk `perform_all_later`), and rendered by `ImageThumbnailComponent` as `image_tag(@image.poster)` + an inline Tailwind play overlay. `ffmpeg` added where the preview is generated/tested: production Dockerfile final stage, both CI rspec jobs, and `bin/setup`.

## Commits

| Commit | What |
|---|---|
| `63acd15` | `Galleries::Image#poster` video preview helper |
| `914bcd3` | Eager poster generation in `ImageProcessingJob` |
| `849931c` | ffmpeg in CI (plan-defect fix — see below) |
| `5341769` | Component poster image + play overlay |
| `da20d35` | `after_party` backfill task (bulk-enqueue, convention-aligned) |
| `47c22c6` | ffmpeg in production Dockerfile |
| `251e44c` | Revert CLAUDE.md note (kept Dockerfile change) |
| `d0399d6` | ffmpeg via `bin/setup` |
| `0a59ead` | E2e spec proving real ffmpeg frame extraction |
| `fc00417` | Simplify: `THUMB_SIZE`/video-prefix constants + `videos` scope |

## Notable deviations from the original plan (reviewer context)

1. **ffmpeg required at test/runtime (plan defect, verified).** The plan claimed specs need no ffmpeg because "`file.preview` only constructs a Preview". False: `ActiveStorage::Blob#preview` raises `UnpreviewableError` unless `previewable?`, and for video `previewable?` requires the ffmpeg binary. Per maintainer decision, ffmpeg was added to both CI rspec jobs + the Dockerfile + `bin/setup` so specs run exactly as written (rather than stubbing). CLAUDE.md documentation of this was reverted at maintainer request; `bin/setup` covers local setup instead.
2. **Backfill convention.** Plan's literal `find_each`/`perform_later` → aligned to the codebase's established `after_party` bulk pattern (`in_batches` + `ActiveJob.perform_all_later`, model scope), matching `20250517231138_backfill_image_perceptual_hash.rake`.
3. **Extra e2e test.** Added one additive spec that genuinely exercises real ffmpeg frame extraction (the plan's specs deliberately only construct/mocked the Preview); existing plan specs left as-written.

## Verification

- Full unit suite: **967 examples, 0 failures**; `standardrb` clean.
- CI: `unit_tests` ✅, `lint` ✅. `system_tests` shows one **unrelated, pre-existing flaky failure** — `spec/system/galleries/image_tags_spec.rb:184` ("refreshes recent tags on visibilitychange"), not touched by this branch, passes on `main`.

## Follow-ups (not in this PR — scope)

- **N+1:** gallery controllers `.includes(:file_attachment)` but not the blob; each tile lazy-loads the blob. Pre-existing (the old `video_tag` path did too), but worth `.includes(file_attachment: :blob)` in `galleries_controller`, `processing_images_controller`, `similar_images_component`.
- This branch is **3 commits behind `main`** (#777/#778) — rebase before merge.
- Detail-view `ImageComponent` + `galleries/books/reads/show.html.erb` still render bare `<video>` — natural next step now that poster + ffmpeg exist.