### PR TITLE
Suggest related tags when adding an image tag

### DIFF
--- a/app/components/galleries/tag_searches/related_tags_box_component.rb
+++ b/app/components/galleries/tag_searches/related_tags_box_component.rb
@@ -1,0 +1,58 @@
+module Galleries
+  module TagSearches
+    class RelatedTagsBoxComponent < ApplicationComponent
+      erb_template <<~ERB
+        <div
+          class="border border-gray-200 rounded-lg p-4 my-2"
+          data-controller="related-tags-box"
+          data-role="related-tags-box"
+        >
+          <div class="flex justify-between items-center">
+            <h4 class="text-md">Related to "<%= @tag.name %>"</h4>
+            <button
+              type="button"
+              aria-label="Dismiss related tags"
+              class="opacity-60 hover:opacity-100 cursor-pointer"
+              data-action="related-tags-box#dismiss"
+            >×</button>
+          </div>
+
+          <hr class="my-3 border-gray-200">
+
+          <div class="space-y-2">
+            <% @related_tags.each do |related| %>
+              <div
+                id="related-suggestion-<%= related.tag.id %>"
+                class="flex items-center gap-3"
+              >
+                <%= render(
+                  Galleries::TagPillComponent.new(tag: related.tag)
+                ) %>
+                <span class="text-xs text-gray-500">
+                  <%= related.shared_count %> shared
+                </span>
+                <%= helpers.button_to(
+                  "Add tag",
+                  gallery_image_tags_path(
+                    @gallery,
+                    @image,
+                    tag_id: related.tag.id,
+                    from_related: true
+                  ),
+                  class: "button button--small ml-auto"
+                ) %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      ERB
+
+      def initialize(tag:, image:, related_tags:)
+        @tag = tag
+        @image = image
+        @gallery = image.gallery
+        @related_tags = related_tags
+      end
+    end
+  end
+end

--- a/app/controllers/galleries/images/tags_controller.rb
+++ b/app/controllers/galleries/images/tags_controller.rb
@@ -10,6 +10,15 @@ module Galleries
         @tag = authorize(find_tag)
 
         @image.add_tag(@tag)
+        @from_related = params[:from_related].present?
+
+        unless @from_related
+          @related_tags = Galleries::RelatedTagsQuery.call(
+            tag: @tag,
+            exclude_tag_ids: @image.tag_ids,
+            limit: 5
+          )
+        end
 
         respond_to do |format|
           format.turbo_stream

--- a/app/javascript/controllers/related_tags_box_controller.js
+++ b/app/javascript/controllers/related_tags_box_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Ensures only the most recently added tag shows a "Related to" box, and
+// handles dismissing the box via the ✕ button.
+export default class extends Controller {
+  connect() {
+    document
+      .querySelectorAll("[data-role='related-tags-box']")
+      .forEach((box) => {
+        if (box !== this.element) box.remove()
+      })
+  }
+
+  dismiss() {
+    this.element.remove()
+  }
+}

--- a/app/queries/galleries/related_tags_query.rb
+++ b/app/queries/galleries/related_tags_query.rb
@@ -4,26 +4,28 @@ module Galleries
 
     def self.call(...) = new(...).call
 
-    def initialize(tag:)
+    def initialize(tag:, exclude_tag_ids: [], limit: 10)
       @tag = tag
+      @exclude_tag_ids = exclude_tag_ids
+      @limit = limit
     end
 
     def call
       Galleries::Tag
         .where(gallery_id: tag.gallery_id)
-        .where.not(id: tag.id)
+        .where.not(id: [tag.id, *exclude_tag_ids])
         .joins(:image_tags)
         .where(galleries_image_tags: {image_id: tag.image_ids})
         .group("galleries_tags.id")
         .select("galleries_tags.*, COUNT(*) AS shared_count")
         .order(Arel.sql("COUNT(*) DESC"))
-        .limit(10)
+        .limit(limit)
         .includes(:gallery)
         .map { Result.new(tag: it, shared_count: it.shared_count.to_i) }
     end
 
     private
 
-    attr_reader :tag
+    attr_reader :tag, :exclude_tag_ids, :limit
   end
 end

--- a/app/views/galleries/images/tags/create.turbo_stream.erb
+++ b/app/views/galleries/images/tags/create.turbo_stream.erb
@@ -1,13 +1,30 @@
 <%= turbo_stream.replace("image-tags") do %>
   <%= render(Galleries::ImageTagsComponent.new(image: @image)) %>
 <% end %>
-<%= turbo_stream.update("tag-search-form") do %>
-  <%= render(Galleries::TagSearches::FormComponent.new(
-    tag_search: Galleries::TagSearch.new(
-      gallery: @image.gallery,
-      image: @image
-    )
-  )) %>
-<% end %>
-<%= turbo_stream.remove("tag-search-result-#{@tag.id}") %>
+
 <%= turbo_stream.remove("recently-added-tag-#{@tag.id}") %>
+
+<% if @from_related %>
+  <%= turbo_stream.remove("related-suggestion-#{@tag.id}") %>
+<% else %>
+  <%= turbo_stream.update("tag-search-form") do %>
+    <%= render(Galleries::TagSearches::FormComponent.new(
+      tag_search: Galleries::TagSearch.new(
+        gallery: @image.gallery,
+        image: @image
+      )
+    )) %>
+  <% end %>
+
+  <% if @related_tags.any? %>
+    <%= turbo_stream.replace("tag-search-result-#{@tag.id}") do %>
+      <%= render(Galleries::TagSearches::RelatedTagsBoxComponent.new(
+        tag: @tag,
+        image: @image,
+        related_tags: @related_tags
+      )) %>
+    <% end %>
+  <% else %>
+    <%= turbo_stream.remove("tag-search-result-#{@tag.id}") %>
+  <% end %>
+<% end %>

--- a/spec/components/galleries/tag_searches/related_tags_box_component_spec.rb
+++ b/spec/components/galleries/tag_searches/related_tags_box_component_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Galleries::TagSearches::RelatedTagsBoxComponent,
+  type: :component do
+  it "renders a box header naming the source tag" do
+    tag = build_stubbed(:galleries_tag, name: "forest")
+    image = build_stubbed(:galleries_image, gallery: tag.gallery)
+    component = described_class.new(tag:, image:, related_tags: [])
+
+    render_inline(component)
+
+    expect(page).to have_css("[data-role=related-tags-box]")
+    expect(page).to have_text("Related to \"forest\"")
+  end
+
+  it "renders a dismiss button wired to the stimulus controller" do
+    tag = build_stubbed(:galleries_tag)
+    image = build_stubbed(:galleries_image, gallery: tag.gallery)
+    component = described_class.new(tag:, image:, related_tags: [])
+
+    render_inline(component)
+
+    expect(page).to have_css(
+      "[data-controller=related-tags-box] " \
+      "button[data-action='related-tags-box#dismiss']"
+    )
+  end
+
+  it "renders a row per related tag with shared count and add button" do
+    gallery = create(:gallery)
+    tag = create(:galleries_tag, gallery:)
+    image = create(:galleries_image, gallery:)
+    related = create(:galleries_tag, gallery:, name: "beach")
+    result = Galleries::RelatedTagsQuery::Result.new(
+      tag: related,
+      shared_count: 3
+    )
+    component = described_class.new(tag:, image:, related_tags: [result])
+
+    render_inline(component)
+
+    add_path = gallery_image_tags_path(
+      gallery, image, tag_id: related.id, from_related: true
+    )
+    row = page.find("#related-suggestion-#{related.id}")
+    within(row) do
+      expect(page).to have_text("3 shared")
+      expect(page).to have_selector("form[action='#{add_path}']")
+      expect(page).to have_button("Add tag")
+    end
+  end
+
+  it "does not mark rows as tag-search-result" do
+    gallery = create(:gallery)
+    tag = create(:galleries_tag, gallery:)
+    image = create(:galleries_image, gallery:)
+    related = create(:galleries_tag, gallery:)
+    result = Galleries::RelatedTagsQuery::Result.new(
+      tag: related, shared_count: 1
+    )
+    component = described_class.new(tag:, image:, related_tags: [result])
+
+    render_inline(component)
+
+    expect(page).to have_no_css("[data-role=tag-search-result]")
+  end
+end

--- a/spec/queries/galleries/related_tags_query_spec.rb
+++ b/spec/queries/galleries/related_tags_query_spec.rb
@@ -103,4 +103,27 @@ RSpec.describe Galleries::RelatedTagsQuery, ".call" do
 
     expect(result).to be_empty
   end
+
+  it "excludes tags whose ids are in exclude_tag_ids" do
+    gallery = create(:gallery)
+    source, partner, excluded = create_list(:galleries_tag, 3, gallery:)
+    image = create(:galleries_image, gallery:)
+    image.add_tag(source, partner, excluded)
+
+    result = described_class.call(tag: source, exclude_tag_ids: [excluded.id])
+
+    expect(result.map(&:tag)).to eql([partner])
+  end
+
+  it "respects a custom limit" do
+    gallery = create(:gallery)
+    source = create(:galleries_tag, gallery:)
+    partners = create_list(:galleries_tag, 5, gallery:)
+    image = create(:galleries_image, gallery:)
+    image.add_tag(source, *partners)
+
+    result = described_class.call(tag: source, limit: 2)
+
+    expect(result.size).to eql(2)
+  end
 end

--- a/spec/requests/galleries/images/tags_controller_spec.rb
+++ b/spec/requests/galleries/images/tags_controller_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe Galleries::Images::TagsController do
+  def turbo_stream_headers
+    {"Accept" => "text/vnd.turbo-stream.html"}
+  end
+
+  describe "create" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+      image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:)
+
+      post(gallery_image_tags_path(gallery, image, tag_id: tag.id))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "adds the tag to the image" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:)
+      login_as(user)
+
+      post(gallery_image_tags_path(gallery, image, tag_id: tag.id))
+
+      expect(image.reload.tags).to include(tag)
+    end
+
+    it "renders a related-tags box when the tag has related tags" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      source = create(:galleries_tag, gallery:, name: "source")
+      partner = create(:galleries_tag, gallery:, name: "partner")
+      create(:galleries_image, gallery:).add_tag(source, partner)
+      login_as(user)
+
+      post(
+        gallery_image_tags_path(gallery, image, tag_id: source.id),
+        headers: turbo_stream_headers
+      )
+
+      expect(response.body).to include("data-role=\"related-tags-box\"")
+      expect(response.body).to include("related-suggestion-#{partner.id}")
+    end
+
+    it "removes the search result row when there are no related tags" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      tag = create(:galleries_tag, gallery:)
+      login_as(user)
+
+      post(
+        gallery_image_tags_path(gallery, image, tag_id: tag.id),
+        headers: turbo_stream_headers
+      )
+
+      expect(response.body).to include("tag-search-result-#{tag.id}")
+      expect(response.body).not_to include("data-role=\"related-tags-box\"")
+    end
+
+    it "excludes tags already on the image from the box" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      source = create(:galleries_tag, gallery:, name: "source")
+      partner = create(:galleries_tag, gallery:, name: "partner")
+      already_on = create(:galleries_tag, gallery:, name: "already")
+      create(:galleries_image, gallery:).add_tag(source, partner, already_on)
+      image.add_tag(already_on)
+      login_as(user)
+
+      post(
+        gallery_image_tags_path(gallery, image, tag_id: source.id),
+        headers: turbo_stream_headers
+      )
+
+      expect(response.body).to include("related-suggestion-#{partner.id}")
+      expect(response.body).not_to include(
+        "related-suggestion-#{already_on.id}"
+      )
+    end
+
+    it "with from_related, removes the suggestion row without a new box" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      image = create(:galleries_image, gallery:)
+      source = create(:galleries_tag, gallery:, name: "source")
+      partner = create(:galleries_tag, gallery:, name: "partner")
+      create(:galleries_image, gallery:).add_tag(source, partner)
+      login_as(user)
+
+      post(
+        gallery_image_tags_path(
+          gallery, image, tag_id: partner.id, from_related: true
+        ),
+        headers: turbo_stream_headers
+      )
+
+      expect(image.reload.tags).to include(partner)
+      expect(response.body).to include("related-suggestion-#{partner.id}")
+      expect(response.body).not_to include("data-role=\"related-tags-box\"")
+    end
+  end
+end

--- a/spec/system/galleries/image_tags_spec.rb
+++ b/spec/system/galleries/image_tags_spec.rb
@@ -198,4 +198,132 @@ RSpec.describe "Gallery image tags", type: :system do
     )
     expect(page).to have_css("[data-role=recent-tag]", text: "seed-tag")
   end
+
+  it "suggests related tags when adding a tag", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    source = create(:galleries_tag, gallery:, name: "source")
+    partner = create(:galleries_tag, gallery:, name: "partner")
+    create(:galleries_image, gallery:).add_tag(source, partner)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "source")
+    expect(page).to have_css("[data-role=tag-search-result]", text: "source")
+    within("[data-role=tag-search-result]", text: "source") do
+      click_on("Add tag")
+    end
+
+    within("[data-role=related-tags-box]") do
+      expect(page).to have_text("Related to \"source\"")
+      expect(page).to have_text("partner")
+      expect(page).to have_text("1 shared")
+    end
+    expect(image.reload.tags.map(&:name)).to include("source")
+  end
+
+  it "adds a related tag from the box and removes its row", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    source = create(:galleries_tag, gallery:, name: "source")
+    partner = create(:galleries_tag, gallery:, name: "partner")
+    create(:galleries_image, gallery:).add_tag(source, partner)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "source")
+    expect(page).to have_css("[data-role=tag-search-result]", text: "source")
+    within("[data-role=tag-search-result]", text: "source") do
+      click_on("Add tag")
+    end
+
+    within("#related-suggestion-#{partner.id}") { click_on("Add tag") }
+
+    expect(page).to have_css("[data-role=tag]", text: "partner")
+    expect(page).not_to have_css("#related-suggestion-#{partner.id}")
+    expect(image.reload.tags.map(&:name)).to include("partner")
+  end
+
+  it "dismisses the related-tags box with the ✕ button", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    source = create(:galleries_tag, gallery:, name: "source")
+    partner = create(:galleries_tag, gallery:, name: "partner")
+    create(:galleries_image, gallery:).add_tag(source, partner)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "source")
+    expect(page).to have_css("[data-role=tag-search-result]", text: "source")
+    within("[data-role=tag-search-result]", text: "source") do
+      click_on("Add tag")
+    end
+    expect(page).to have_css("[data-role=related-tags-box]")
+
+    find("[aria-label='Dismiss related tags']").click
+
+    expect(page).not_to have_css("[data-role=related-tags-box]")
+  end
+
+  it "shows only the most recent box when adding two tags", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    one = create(:galleries_tag, gallery:, name: "shared one")
+    one_partner = create(:galleries_tag, gallery:, name: "one partner")
+    two = create(:galleries_tag, gallery:, name: "shared two")
+    two_partner = create(:galleries_tag, gallery:, name: "two partner")
+    create(:galleries_image, gallery:).add_tag(one, one_partner)
+    create(:galleries_image, gallery:).add_tag(two, two_partner)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "shared")
+    expect(page).to have_css(
+      "[data-role=tag-search-result]",
+      text: "shared one"
+    )
+    within("[data-role=tag-search-result]", text: "shared one") do
+      click_on("Add tag")
+    end
+    expect(page).to have_text("Related to \"shared one\"")
+
+    within("[data-role=tag-search-result]", text: "shared two") do
+      click_on("Add tag")
+    end
+
+    expect(page).to have_text("Related to \"shared two\"")
+    expect(page).not_to have_text("Related to \"shared one\"")
+    expect(page).to have_css("[data-role=related-tags-box]", count: 1)
+  end
+
+  it "clears the box when starting a new search", :js do
+    user = create(:user)
+    gallery = create(:gallery, user:)
+    image = create(:galleries_image, gallery:)
+    source = create(:galleries_tag, gallery:, name: "source")
+    partner = create(:galleries_tag, gallery:, name: "partner")
+    create(:galleries_image, gallery:).add_tag(source, partner)
+    login_as(user)
+
+    visit(gallery_image_path(gallery, image))
+
+    fill_in("Tag search query", with: "source")
+    expect(page).to have_css("[data-role=tag-search-result]", text: "source")
+    within("[data-role=tag-search-result]", text: "source") do
+      click_on("Add tag")
+    end
+    expect(page).to have_css("[data-role=related-tags-box]")
+
+    fill_in("Tag search query", with: "partner")
+
+    expect(page).not_to have_css("[data-role=related-tags-box]")
+  end
 end


### PR DESCRIPTION
## Summary

Related tags phase 2: when you add a tag to an image on
`/galleries/:gallery_id/images/:id`, the just-added tag's search-result row is
replaced in place with a bordered **"Related to {tag}"** box listing
co-occurring tags (excluding tags already on the image), each with a
co-occurrence count and an "Add tag" button.

- Adding a tag from the box removes only that row (no nested/recursive
  suggestions).
- Only the most-recently-added tag shows a box; adding another collapses the
  previous one.
- A new search or the ✕ button dismisses the box.
- Tags with no co-occurrences just remove the row (today's behavior) — no empty
  box.
- Enter / auto-add is unchanged: box rows are not `data-role=tag-search-result`.

The tag show page's existing Related-tags card is untouched
(`RelatedTagsQuery` defaults are preserved).

## Changes

- **`Galleries::RelatedTagsQuery`** — added optional `exclude_tag_ids:` and
  `limit:` kwargs (defaults preserve current behavior).
- **`Galleries::TagSearches::RelatedTagsBoxComponent`** — renders the box inside
  the `tag-search-results` turbo-frame.
- **`related-tags-box` Stimulus controller** — collapse-previous on `connect()`,
  `dismiss()` for the ✕.
- **`Galleries::Images::TagsController#create`** + `create.turbo_stream.erb` —
  compute related tags and branch box vs. plain row-removal; `from_related`
  marks box-originated adds.

## Testing

- Query, component, and request specs (TDD).
- Five new `:js` system specs covering suggest, add-from-box, dismiss,
  collapse-previous, and clear-on-search.
- Full suite green (1100 examples), standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
