### PR TITLE
Color tag index cards by classification

### DIFF
--- a/app/components/galleries/tag_card_component.rb
+++ b/app/components/galleries/tag_card_component.rb
@@ -1,0 +1,52 @@
+module Galleries
+  class TagCardComponent < ApplicationComponent
+    CLASSIFICATION_CARD_CLASSES = {
+      "none" =>
+        "border-gray-200 hover:bg-gray-50 hover:border-gray-300",
+      "subject" =>
+        "bg-purple-50 border-purple-200 " \
+        "hover:bg-purple-100 hover:border-purple-300",
+      "system" =>
+        "bg-red-50 border-red-200 " \
+        "hover:bg-red-100 hover:border-red-300",
+      "artist" =>
+        "bg-teal-50 border-teal-200 " \
+        "hover:bg-teal-100 hover:border-teal-300"
+    }.freeze
+
+    erb_template <<~ERB
+      <%= link_to(
+        gallery_tag_path(@tag.gallery, @tag),
+        data: {role: "tag"},
+        class: @card_classes
+      ) do %>
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-2">
+            <span class="font-medium text-gray-900 group-hover:text-gray-700"><%= @tag.name %></span>
+            <%= render(
+              Galleries::TagClassificationPillComponent.new(tag: @tag)
+            ) %>
+          </div>
+          <span class="text-sm text-gray-500 bg-gray-100 px-2 py-1 rounded-full"><%= @tag.image_tags_count %></span>
+        </div>
+      <% end %>
+    ERB
+
+    def initialize(tag:)
+      @tag = tag
+      @card_classes = card_classes_for(tag.classification)
+    end
+
+    private
+
+    def card_classes_for(classification)
+      base = "block p-4 border rounded-lg " \
+        "transition-colors duration-200 group"
+      variant = CLASSIFICATION_CARD_CLASSES.fetch(
+        classification,
+        CLASSIFICATION_CARD_CLASSES.fetch("none")
+      )
+      "#{base} #{variant}"
+    end
+  end
+end

--- a/app/components/galleries/tag_card_component.rb
+++ b/app/components/galleries/tag_card_component.rb
@@ -44,7 +44,7 @@ module Galleries
         "transition-colors duration-200 group"
       variant = CLASSIFICATION_CARD_CLASSES.fetch(
         classification,
-        CLASSIFICATION_CARD_CLASSES.fetch("none")
+        CLASSIFICATION_CARD_CLASSES["none"]
       )
       "#{base} #{variant}"
     end

--- a/app/controllers/galleries/tags_controller.rb
+++ b/app/controllers/galleries/tags_controller.rb
@@ -6,7 +6,10 @@ module Galleries
     def index
       @gallery = find_gallery
       authorize Galleries::Tag
-      @tags = policy_scope(Galleries::Tag).where(gallery: @gallery).order(:name)
+      @tags = policy_scope(Galleries::Tag)
+        .where(gallery: @gallery)
+        .includes(:gallery)
+        .order(:name)
     end
 
     def new

--- a/app/views/galleries/tags/index.html.erb
+++ b/app/views/galleries/tags/index.html.erb
@@ -24,21 +24,7 @@
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
   <% @tags.each do |tag| %>
-    <%= link_to(
-      gallery_tag_path(@gallery, tag),
-      data: {role: "tag"},
-      class: "block p-4 border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-colors duration-200 group"
-    ) do %>
-      <div class="flex justify-between items-center">
-        <div class="flex items-center gap-2">
-          <span class="font-medium text-gray-900 group-hover:text-gray-700"><%= tag.name %></span>
-          <%= render(
-            Galleries::TagClassificationPillComponent.new(tag:)
-          ) %>
-        </div>
-        <span class="text-sm text-gray-500 bg-gray-100 px-2 py-1 rounded-full"><%= tag.image_tags_count %></span>
-      </div>
-    <% end %>
+    <%= render(Galleries::TagCardComponent.new(tag:)) %>
   <% end %>
 </div>
 

--- a/spec/components/galleries/tag_card_component_spec.rb
+++ b/spec/components/galleries/tag_card_component_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Galleries::TagCardComponent, type: :component do
+  it "links to the tag page and shows the name" do
+    tag = build_stubbed(:galleries_tag, name: "Nature")
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_css(
+      "a[data-role=tag][href='#{gallery_tag_path(tag.gallery, tag)}']",
+      text: "Nature"
+    )
+  end
+
+  it "shows the image tags count" do
+    tag = build_stubbed(:galleries_tag, image_tags_count: 5)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_text("5")
+  end
+
+  it "uses gray styling for none classification" do
+    tag = build_stubbed(:galleries_tag)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_css("a[data-role=tag].border-gray-200")
+  end
+
+  it "tints the background purple for subject classification" do
+    tag = build_stubbed(:galleries_tag, classification: :subject)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_css("a[data-role=tag].bg-purple-50")
+  end
+
+  it "tints the background red for system classification" do
+    tag = build_stubbed(:galleries_tag, classification: :system)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_css("a[data-role=tag].bg-red-50")
+  end
+
+  it "tints the background teal for artist classification" do
+    tag = build_stubbed(:galleries_tag, classification: :artist)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_css("a[data-role=tag].bg-teal-50")
+  end
+
+  it "renders the classification pill for classified tags" do
+    tag = build_stubbed(:galleries_tag, classification: :subject)
+    render_inline(described_class.new(tag:))
+
+    expect(page).to have_text("subject")
+  end
+end

--- a/spec/requests/galleries/tags_controller_spec.rb
+++ b/spec/requests/galleries/tags_controller_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe Galleries::TagsController do
       expect(tag_card).not_to have_text("none")
     end
 
+    it "tints the card background by classification" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      create(
+        :galleries_tag,
+        gallery:,
+        name: "Alice",
+        classification: :subject
+      )
+      login_as(user)
+
+      get(gallery_tags_path(gallery))
+
+      expect(page).to have_css("[data-role=tag].bg-purple-50")
+    end
+
     it "returns 404 when accessing tags for gallery not owned by current user" do
       gallery = create(:gallery)
       create(:galleries_tag, gallery:)


### PR DESCRIPTION
## Summary
On the tag index (`/galleries/:id/tags`), all tags rendered with the same neutral gray card. This tints each card's background based on the tag's `classification`, so categories are visually distinct — mirroring how `Galleries::TagPillComponent` maps classification to a color.

- Extracts the inline tag-card markup into a new `Galleries::TagCardComponent`.
- The component maps `classification` → subtle `-50` backgrounds with `-200`/`-300` borders and hovers (lighter than the pill's full-strength `-100`/`-800` shades, which are too heavy for a whole card).
- `none` (unclassified) keeps today's neutral gray look so colored tags stand out.
- Subject → purple, system → red, artist → teal.

## Testing
- `Galleries::TagCardComponent` component spec (7 examples) covering link/name/count and each classification's background.
- Added a request spec asserting the index tints the card background by classification.
- Full `tags_controller_spec` passes (37 examples) — `data-role="tag"`, the tag name, and the classification pill are all preserved.
- Verified Tailwind emits the new `bg-purple-50`, `bg-red-50`, `bg-teal-50` utilities.

Implements the "tag index isn't colored by category" backlog ticket.