### PR TITLE
Sort plants index by name

### DIFF
--- a/app/controllers/plants/plants_controller.rb
+++ b/app/controllers/plants/plants_controller.rb
@@ -8,7 +8,7 @@ module Plants
       @plants =
         policy_scope(Plants::Plant)
           .includes(key_image: :file_attachment)
-          .order(created_at: :desc)
+          .order(:name)
     end
 
     def new

--- a/spec/requests/plants/plants_controller_spec.rb
+++ b/spec/requests/plants/plants_controller_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe "Plants::Plants", type: :request do
       expect(page).not_to have_content(other_plant.name)
     end
 
+    it "sorts plants by name" do
+      user = create(:user)
+      create(:plant, user:, name: "Zebra Plant")
+      create(:plant, user:, name: "Aloe Vera")
+      create(:plant, user:, name: "Monstera")
+      login_as(user, scope: :user)
+
+      get(plants_path)
+
+      body = response.body
+      expect(body.index("Aloe Vera")).to be < body.index("Monstera")
+      expect(body.index("Monstera")).to be < body.index("Zebra Plant")
+    end
+
     it "renders key image when present" do
       user = create(:user)
       plant = create(:plant, user:)


### PR DESCRIPTION
## Summary
- Sort plants on the index page alphabetically by name instead of creation date

## Test plan
- [x] New request spec verifies plants are ordered alphabetically
- [ ] Manually load /plants and confirm alphabetical order