### PR TITLE
Format purchased_at as date only on plant show page

### DIFF
--- a/app/views/plants/plants/show.html.erb
+++ b/app/views/plants/plants/show.html.erb
@@ -37,7 +37,7 @@
     <% if @plant.purchased_at.present? %>
       <div>
         <span class="font-medium">Purchased at:</span>
-        <%= l(@plant.purchased_at) %>
+        <%= l(@plant.purchased_at.to_date) %>
       </div>
     <% end %>
     <% if @plant.purchased_from.present? %>

--- a/spec/requests/plants/plants_controller_spec.rb
+++ b/spec/requests/plants/plants_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Plants::Plants", type: :request do
 
     it "renders purchase details when present" do
       user = create(:user)
-      purchased_at = Time.current
+      purchased_at = Time.zone.local(2024, 3, 16, 10, 30, 0)
       plant = create(
         :plant,
         user:,
@@ -196,7 +196,8 @@ RSpec.describe "Plants::Plants", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Purchase")
       expect(response.body).to include("Purchased at:")
-      expect(response.body).to include(I18n.l(purchased_at))
+      expect(response.body).to include(I18n.l(purchased_at.to_date))
+      expect(response.body).not_to include("10:30")
       expect(response.body).to include("Purchased from:")
       expect(response.body).to include("Home Depot")
     end


### PR DESCRIPTION
## Summary
- The plant show page rendered `Purchased at` via `l(@plant.purchased_at)`, which uses the default `:datetime` format and includes the time-of-day (e.g. `Sat, 16 Mar 2024 00:00:00 +0000`).
- Cast to `to_date` so only the date is shown.
- Updated the request spec to lock in date-only output and assert the time portion is no longer present.

Closes the Notion ticket "Format purchased at for plants".

## Test plan
- [x] `bin/rspec spec/requests/plants/plants_controller_spec.rb`
- [x] `bin/rspec` (full suite, 1110 examples, 0 failures)