### PR TITLE
Add died_at to plants

### DIFF
--- a/app/controllers/plants/plants_controller.rb
+++ b/app/controllers/plants/plants_controller.rb
@@ -59,7 +59,7 @@ module Plants
     def plant_params
       params.expect(
         plants_plant: %i[
-          name purchased_at purchased_from notes
+          name purchased_at purchased_from died_at notes
         ]
       )
     end

--- a/app/models/plants/plant.rb
+++ b/app/models/plants/plant.rb
@@ -4,6 +4,7 @@
 # Database name: primary
 #
 #  id             :bigint           not null, primary key
+#  died_at        :datetime
 #  name           :string           not null
 #  purchased_at   :datetime
 #  purchased_from :string

--- a/app/views/plants/plants/_form.html.erb
+++ b/app/views/plants/plants/_form.html.erb
@@ -5,6 +5,7 @@
   <%= form.input(:name, autofocus: true) %>
   <%= form.input(:purchased_from) %>
   <%= form.input(:purchased_at, as: :date, html5: true) %>
+  <%= form.input(:died_at, as: :date, html5: true) %>
   <%= form.rich_text_area(:notes) %>
-  <%= form.button(:submit) %>
+  <%= form.button(:submit, class: "mt-4") %>
 <% end %>

--- a/app/views/plants/plants/show.html.erb
+++ b/app/views/plants/plants/show.html.erb
@@ -49,6 +49,16 @@
   </div>
 <% end %>
 
+<% if @plant.died_at.present? %>
+  <div class="mt-8">
+    <h2 class="text-lg font-medium mb-2">Died</h2>
+    <div>
+      <span class="font-medium">Died at:</span>
+      <%= l(@plant.died_at.to_date) %>
+    </div>
+  </div>
+<% end %>
+
 <div class="mt-8">
   <h2 class="text-lg font-medium mb-3">Images</h2>
   <% if @plant_images.any? %>

--- a/db/migrate/20260616130814_add_died_at_to_plants_plants.rb
+++ b/db/migrate/20260616130814_add_died_at_to_plants_plants.rb
@@ -1,0 +1,5 @@
+class AddDiedAtToPlantsPlants < ActiveRecord::Migration[8.1]
+  def change
+    add_column(:plants_plants, :died_at, :datetime)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_01_144451) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_130814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -170,6 +170,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_144451) do
 
   create_table "plants_plants", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.datetime "died_at"
     t.bigint "key_image_id"
     t.string "name", null: false
     t.datetime "purchased_at"

--- a/spec/factories/plants/plants.rb
+++ b/spec/factories/plants/plants.rb
@@ -4,6 +4,7 @@
 # Database name: primary
 #
 #  id             :bigint           not null, primary key
+#  died_at        :datetime
 #  name           :string           not null
 #  purchased_at   :datetime
 #  purchased_from :string

--- a/spec/models/plants/plant_spec.rb
+++ b/spec/models/plants/plant_spec.rb
@@ -4,6 +4,7 @@
 # Database name: primary
 #
 #  id             :bigint           not null, primary key
+#  died_at        :datetime
 #  name           :string           not null
 #  purchased_at   :datetime
 #  purchased_from :string

--- a/spec/requests/plants/plants_controller_spec.rb
+++ b/spec/requests/plants/plants_controller_spec.rb
@@ -202,6 +202,30 @@ RSpec.describe "Plants::Plants", type: :request do
       expect(response.body).to include("Home Depot")
     end
 
+    it "renders died_at when present" do
+      user = create(:user)
+      died_at = Time.zone.local(2024, 5, 4, 9, 0, 0)
+      plant = create(:plant, user:, died_at:)
+      login_as(user, scope: :user)
+
+      get(plant_path(plant))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Died")
+      expect(response.body).to include("Died at:")
+      expect(response.body).to include(I18n.l(died_at.to_date))
+    end
+
+    it "does not render died section when died_at is blank" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      login_as(user, scope: :user)
+
+      get(plant_path(plant))
+
+      expect(response.body).not_to include("Died at:")
+    end
+
     it "redirects when viewing another user's plant" do
       user = create(:user)
       other_plant = create(:plant)
@@ -299,13 +323,17 @@ RSpec.describe "Plants::Plants", type: :request do
       user = create(:user)
       plant = create(:plant, user:, name: "Old Name")
       login_as(user, scope: :user)
-      params = {plants_plant: {name: "New Name"}}
+      params = {
+        plants_plant: {name: "New Name", died_at: "2024-05-04"}
+      }
 
       patch(plant_path(plant), params:)
 
       expect(response).to redirect_to(plant_path(plant))
       expect(flash[:notice]).to eq("Plant was updated.")
-      expect(plant.reload.name).to eq("New Name")
+      plant.reload
+      expect(plant.name).to eq("New Name")
+      expect(plant.died_at.to_date).to eq(Date.new(2024, 5, 4))
     end
 
     it "renders edit form with errors when validation fails" do


### PR DESCRIPTION
## Summary
- Adds optional `died_at` datetime column to `plants_plants` to mark a plant as deceased
- Edit/new form exposes it as a date input; show page renders a "Died" section when present
- Adds a top margin to the form submit button so it no longer hugs the rich-text notes editor

Notion: https://app.notion.com/p/jutonz/Add-died_at-to-plants-381299751461808aa420dc937d9d4052

## Test plan
- [x] `bin/rspec spec/requests/plants/plants_controller_spec.rb spec/models/plants/plant_spec.rb spec/system/plants_spec.rb`
- [x] `bin/standardrb`
- [ ] Visit `/plants/:id/edit`, set a date, save, and confirm the show page renders the Died section