### PR TITLE
Auto-assign first uploaded image as plant's key image

### DIFF
--- a/app/models/plants/plant_image_upload.rb
+++ b/app/models/plants/plant_image_upload.rb
@@ -30,15 +30,23 @@ module Plants
     def create_images(files)
       saved = true
       plant_image = nil
+      first_saved = nil
 
       Plants::PlantImage.transaction do
         files.each do |file|
           current = @plant.plant_images.new(file:, taken_at: @taken_at)
-          next if current.save
+          if current.save
+            first_saved ||= current
+            next
+          end
 
           plant_image = current
           saved = false
-          raise ActiveRecord::Rollback
+          raise(ActiveRecord::Rollback)
+        end
+
+        if saved && first_saved && @plant.key_image_id.nil?
+          @plant.update!(key_image: first_saved)
         end
       end
 

--- a/spec/models/plants/plant_image_upload_spec.rb
+++ b/spec/models/plants/plant_image_upload_spec.rb
@@ -27,6 +27,58 @@ RSpec.describe Plants::PlantImageUpload do
       expect(result.saved?).to(eq(true))
     end
 
+    it "sets the new image as the key image when none is set" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      files = [fixture_file_upload("audiosurf.jpg", "image/jpeg")]
+
+      service = described_class.new(
+        plant:,
+        files:,
+        taken_at: "2024-01-02"
+      )
+
+      service.save
+
+      expect(plant.reload.key_image).to(eq(plant.plant_images.first))
+    end
+
+    it "sets the first image as the key image when uploading many" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      files = [
+        fixture_file_upload("audiosurf.jpg", "image/jpeg"),
+        fixture_file_upload("audiosurf.jpg", "image/jpeg")
+      ]
+
+      service = described_class.new(
+        plant:,
+        files:,
+        taken_at: "2024-01-02"
+      )
+
+      service.save
+
+      expect(plant.reload.key_image).to(eq(plant.plant_images.first))
+    end
+
+    it "preserves the existing key image when one is already set" do
+      user = create(:user)
+      plant = create(:plant, user:)
+      existing = create(:plants_plant_image, plant:)
+      plant.update!(key_image: existing)
+
+      service = described_class.new(
+        plant:,
+        files: [fixture_file_upload("audiosurf.jpg", "image/jpeg")],
+        taken_at: "2024-01-02"
+      )
+
+      service.save
+
+      expect(plant.reload.key_image).to(eq(existing))
+    end
+
     it "returns errors when no files are provided" do
       user = create(:user)
       plant = create(:plant, user:)

--- a/spec/models/plants/plant_image_upload_spec.rb
+++ b/spec/models/plants/plant_image_upload_spec.rb
@@ -27,23 +27,7 @@ RSpec.describe Plants::PlantImageUpload do
       expect(result.saved?).to(eq(true))
     end
 
-    it "sets the new image as the key image when none is set" do
-      user = create(:user)
-      plant = create(:plant, user:)
-      files = [fixture_file_upload("audiosurf.jpg", "image/jpeg")]
-
-      service = described_class.new(
-        plant:,
-        files:,
-        taken_at: "2024-01-02"
-      )
-
-      service.save
-
-      expect(plant.reload.key_image).to(eq(plant.plant_images.first))
-    end
-
-    it "sets the first image as the key image when uploading many" do
+    it "sets the first new image as the key image when none is set" do
       user = create(:user)
       plant = create(:plant, user:)
       files = [


### PR DESCRIPTION
## Summary
- When a plant has no key image, the first newly uploaded image is now automatically set as the key image
- Logic lives in `Plants::PlantImageUpload#create_images` inside the existing transaction, so a rollback discards the assignment too
- Existing key images are preserved when present

## Test plan
- [x] `bin/rspec spec/models/plants/plant_image_upload_spec.rb`
- [x] `bin/rspec spec/models/plants spec/requests/plants spec/components/plants`
- [x] `bin/standardrb` on changed files
- [ ] Manually upload an image to a plant with no key image and confirm the plant card shows it as the thumbnail