### PR TITLE
Eager-load Active Storage blob in gallery image grids

### DIFF
--- a/app/components/galleries/similar_images_component.rb
+++ b/app/components/galleries/similar_images_component.rb
@@ -38,7 +38,7 @@ module Galleries
       @similar_images =
         scope
           .includes(:gallery)
-          .includes(:file_attachment)
+          .includes(file_attachment: :blob)
           .page(page)
           .per(PER_PAGE)
     end

--- a/app/controllers/galleries/books/reads_controller.rb
+++ b/app/controllers/galleries/books/reads_controller.rb
@@ -6,7 +6,7 @@ module Galleries
       def show
         @gallery = find_gallery
         @book = authorize(find_book)
-        @images = @book.images.includes(:file_attachment)
+        @images = @book.images.includes(file_attachment: :blob)
       end
 
       private

--- a/app/controllers/galleries/books_controller.rb
+++ b/app/controllers/galleries/books_controller.rb
@@ -21,7 +21,7 @@ module Galleries
         @book
           .images
           .includes(:gallery)
-          .includes(:file_attachment)
+          .includes(file_attachment: :blob)
           .page(params[:page])
           .per(PER_PAGE)
     end

--- a/app/controllers/galleries/processing_images_controller.rb
+++ b/app/controllers/galleries/processing_images_controller.rb
@@ -13,7 +13,7 @@ module Galleries
         policy_scope(Galleries::Image)
           .where(gallery: @gallery)
           .unprocessed
-          .includes(:gallery, :file_attachment)
+          .includes(:gallery, file_attachment: :blob)
     end
 
     private

--- a/app/controllers/galleries/tags_controller.rb
+++ b/app/controllers/galleries/tags_controller.rb
@@ -25,7 +25,7 @@ module Galleries
       @images =
         @tag
           .images
-          .includes(:file_attachment)
+          .includes(file_attachment: :blob)
           .includes(:gallery)
           .order(created_at: :desc)
           .page(params[:page])

--- a/app/controllers/galleries_controller.rb
+++ b/app/controllers/galleries_controller.rb
@@ -21,7 +21,7 @@ class GalleriesController < ApplicationController
       @gallery
         .images
         .processed
-        .includes(:file_attachment)
+        .includes(file_attachment: :blob)
         .order(created_at: :desc)
         .then { @filter_tags.any? ? it.by_tags(@filter_tags) : it }
         .page(params[:page])

--- a/bin/worktree-setup
+++ b/bin/worktree-setup
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Prepare a fresh git worktree.
 #
-# A fresh worktree is missing two gitignored things it needs:
+# A fresh worktree is missing three gitignored things it needs:
 #   - per-environment credential keys (config/credentials/*.key)
 #   - compiled assets (tailwind.css, etc.)
+#   - node_modules (the Playwright driver that system specs launch via
+#     `npm exec`; without it, browser specs hang waiting on a handshake
+#     that never comes)
 # Gems and the database are shared across worktrees, so `bundle install`
 # and `db:prepare` are not needed. This copies the keys from the main
-# checkout (no 1Password prompt, unlike bin/setup) and builds assets.
+# checkout (no 1Password prompt, unlike bin/setup), installs node
+# modules, and builds assets.
 #
 # Idempotent. No-op when run outside a linked worktree.
 set -euo pipefail
@@ -26,6 +30,12 @@ for env in development test production; do
   cp "$main_root/config/credentials/$env.key" \
     "config/credentials/$env.key"
 done
+
+echo "Installing node modules (Playwright driver for system specs)"
+npm ci
+
+echo "Ensuring the Playwright browser is installed"
+npm exec --no -- playwright install chromium >/dev/null 2>&1
 
 echo "Precompiling assets"
 mise exec -- bin/rails assets:precompile >/dev/null 2>&1


### PR DESCRIPTION
## Problem

Gallery pages that render `Galleries::ImageThumbnailComponent` (and the `books/reads` inline grid) eager-loaded only the Active Storage `:file_attachment`, not its `:blob`. Each tile then lazy-loaded the blob via `attachment -> blob` delegation — `video?`/`content_type`, `poster`, and variant/file URL signing all touch the blob — producing **one extra `SELECT ... FROM active_storage_blobs` per image**. A 20-image page fired ~20 extra queries.

This is a pre-existing N+1 (flagged during the #779 `simplify` review and deliberately left out to keep that PR scoped).

## Fix

Add the blob to the eager load at each affected Galleries call site via `.includes(file_attachment: :blob)`:

- `galleries#show`
- `galleries/processing_images#show`
- `galleries/tags#show`
- `galleries/books#show`
- `galleries/books/reads#show`
- `Galleries::SimilarImagesComponent`

Pure performance fix — identical rendered output, just one batched blob query instead of N.

### Why not `with_attached_file`?

The generated `with_attached_file` scope expands to `file_attachment: { blob: { variant_records: …, preview_image_attachment: … } }`. Those extra associations aren't used by the thumbnail render path, so it trips **Bullet's unused-eager-loading detector** in system specs (`AVOID eager loading detected: ActiveStorage::Blob => [:variant_records, :preview_image_attachment]`). The narrow `includes(file_attachment: :blob)` loads exactly what's touched.

## Also: `bin/worktree-setup` installs node modules

While verifying the system specs, found that a fresh git worktree had no `node_modules`, so Playwright (launched via `npm exec`) hung waiting on a connection handshake — system specs were unrunnable in worktrees. Added `npm ci` + an idempotent `playwright install chromium` to `bin/worktree-setup`. Separate commit.

## Audit notes

- `galleries/images#index` was checked and left unchanged (no template renders thumbnails there).
- The Plants module is out of scope; `plants#index` already uses `file_attachment: :blob` as precedent.

## Testing

- Non-system specs: `1010 examples, 0 failures`; gallery request/component specs: `252 examples, 0 failures`.
- Gallery **system** specs (Playwright) pass with the narrow include (the prior `with_attached_file` attempt failed them via Bullet). One unrelated `visibilitychange` test in `image_tags_spec` is flaky under full-suite load and passes on retry.
- `standardrb` clean.