### PR TITLE
Add Galleries::RemoteVideoDownload data model

### DIFF
--- a/app/models/galleries/remote_video_download.rb
+++ b/app/models/galleries/remote_video_download.rb
@@ -1,0 +1,20 @@
+module Galleries
+  class RemoteVideoDownload < ApplicationRecord
+    belongs_to :gallery
+    belongs_to :image,
+      class_name: "Galleries::Image",
+      optional: true
+
+    enum :status,
+      {
+        pending: "pending",
+        downloading: "downloading",
+        completed: "completed",
+        failed: "failed"
+      },
+      validate: true,
+      prefix: true
+
+    validates :url, presence: true
+  end
+end

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -32,6 +32,9 @@ class Gallery < ActiveRecord::Base
   has_many :books,
     class_name: "Galleries::Book",
     dependent: :destroy
+  has_many :remote_video_downloads,
+    class_name: "Galleries::RemoteVideoDownload",
+    dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 

--- a/db/migrate/20260627170754_create_galleries_remote_video_downloads.rb
+++ b/db/migrate/20260627170754_create_galleries_remote_video_downloads.rb
@@ -1,0 +1,30 @@
+class CreateGalleriesRemoteVideoDownloads < ActiveRecord::Migration[8.1]
+  def change
+    create_enum(
+      :galleries_remote_video_download_status,
+      %w[pending downloading completed failed]
+    )
+
+    create_table :galleries_remote_video_downloads do |t|
+      t.references(
+        :gallery,
+        null: false,
+        foreign_key: {to_table: :galleries}
+      )
+      t.references(
+        :image,
+        null: true,
+        foreign_key: {to_table: :galleries_images, on_delete: :nullify}
+      )
+      t.string(:url, null: false)
+      t.enum(
+        :status,
+        enum_type: :galleries_remote_video_download_status,
+        null: false,
+        default: "pending"
+      )
+      t.text(:error_message)
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_16_130814) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_27_170754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "galleries_remote_video_download_status", ["pending", "downloading", "completed", "failed"]
   create_enum "galleries_tag_classification", ["none", "subject", "system", "artist"]
 
   create_table "action_text_rich_texts", force: :cascade do |t|
@@ -127,6 +128,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_130814) do
     t.datetime "processed_at"
     t.datetime "updated_at", null: false
     t.index ["gallery_id"], name: "index_galleries_images_on_gallery_id"
+  end
+
+  create_table "galleries_remote_video_downloads", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.text "error_message"
+    t.bigint "gallery_id", null: false
+    t.bigint "image_id"
+    t.enum "status", default: "pending", null: false, enum_type: "galleries_remote_video_download_status"
+    t.datetime "updated_at", null: false
+    t.string "url", null: false
+    t.index ["gallery_id"], name: "index_galleries_remote_video_downloads_on_gallery_id"
+    t.index ["image_id"], name: "index_galleries_remote_video_downloads_on_image_id"
   end
 
   create_table "galleries_social_media_links", force: :cascade do |t|
@@ -517,6 +530,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_16_130814) do
   add_foreign_key "galleries_image_tags", "galleries_images", column: "image_id"
   add_foreign_key "galleries_image_tags", "galleries_tags", column: "tag_id"
   add_foreign_key "galleries_images", "galleries"
+  add_foreign_key "galleries_remote_video_downloads", "galleries"
+  add_foreign_key "galleries_remote_video_downloads", "galleries_images", column: "image_id", on_delete: :nullify
   add_foreign_key "galleries_social_media_links", "galleries_tags", column: "tag_id"
   add_foreign_key "galleries_tags", "galleries"
   add_foreign_key "galleries_tags", "users"

--- a/spec/factories/galleries/remote_video_downloads.rb
+++ b/spec/factories/galleries/remote_video_downloads.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :galleries_remote_video_download,
+    class: "Galleries::RemoteVideoDownload" do
+    gallery
+    sequence(:url) { "https://example.com/video/#{it}.mp4" }
+    status { "pending" }
+  end
+end

--- a/spec/models/galleries/remote_video_download_spec.rb
+++ b/spec/models/galleries/remote_video_download_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Galleries::RemoteVideoDownload do
+  it { is_expected.to belong_to(:gallery) }
+  it { is_expected.to belong_to(:image).optional }
+
+  it { is_expected.to validate_presence_of(:url) }
+
+  it {
+    is_expected.to define_enum_for(:status)
+      .with_values(
+        pending: "pending",
+        downloading: "downloading",
+        completed: "completed",
+        failed: "failed"
+      )
+      .backed_by_column_of_type(:enum)
+      .with_prefix(:status)
+  }
+
+  it "has a valid factory" do
+    expect(build(:galleries_remote_video_download)).to be_valid
+  end
+end

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Gallery do
   it { is_expected.to have_many(:tags) }
   it { is_expected.to have_many(:books) }
 
+  it {
+    is_expected.to have_many(:remote_video_downloads)
+      .class_name("Galleries::RemoteVideoDownload")
+      .dependent(:destroy)
+  }
+
   it { is_expected.to validate_presence_of(:name) }
 
   describe "uniqueness validation" do


### PR DESCRIPTION
Implements the [data model ticket](https://app.notion.com/p/38c29975146181e68509ee9434798067) for `Galleries::RemoteVideoDownload` — pure data layer, no HTTP/jobs/UI.

## Changes
- **Migration**: new table `galleries_remote_video_downloads` + postgres native enum `galleries_remote_video_download_status` (`pending`/`downloading`/`completed`/`failed`).
  - `gallery_id` (NOT NULL FK), `image_id` (nullable FK, `on_delete: :nullify`), `url` (NOT NULL), `status` (enum, default `pending`), `error_message` (text), timestamps.
- **Model** `Galleries::RemoteVideoDownload`: `belongs_to :gallery`, optional `belongs_to :image`, prefixed/validated `enum :status`, `validates :url, presence: true`.
- **Factory** with a `url` sequence + **model spec** (shoulda matchers).
- **Reverse association**: `Gallery has_many :remote_video_downloads, dependent: :destroy` + spec.

## Verification
- `bin/standardrb` clean.
- Model suite green (334 examples, 0 failures).