### PR TITLE
Submit UI for remote video downloads

### DIFF
--- a/app/components/galleries/remote_video_download_pill_component.rb
+++ b/app/components/galleries/remote_video_download_pill_component.rb
@@ -1,0 +1,21 @@
+module Galleries
+  class RemoteVideoDownloadPillComponent < ApplicationComponent
+    STATUS_COLORS = {
+      "pending" => :gray,
+      "downloading" => :blue,
+      "completed" => :green,
+      "failed" => :red
+    }.freeze
+
+    erb_template <<~ERB
+      <%= render(PillComponent.new(
+        text: @remote_video_download.status,
+        color: STATUS_COLORS.fetch(@remote_video_download.status, :gray)
+      )) %>
+    ERB
+
+    def initialize(remote_video_download:)
+      @remote_video_download = remote_video_download
+    end
+  end
+end

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -3,6 +3,16 @@ module Galleries
     before_action :ensure_authenticated!
     after_action :verify_authorized
 
+    def index
+      @gallery = find_gallery
+      @remote_video_downloads = authorize(
+        @gallery.remote_video_downloads.new,
+        :index?
+      ).then do
+        @gallery.remote_video_downloads.order(created_at: :desc)
+      end
+    end
+
     def new
       @gallery = find_gallery
       @remote_video_download = authorize(

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -10,10 +10,37 @@ module Galleries
       )
     end
 
+    def create
+      @gallery = find_gallery
+      @remote_video_download = authorize(
+        @gallery.remote_video_downloads.build(
+          remote_video_download_params
+        )
+      )
+
+      if @remote_video_download.save
+        Galleries::RemoteVideoDownloadJob.perform_later(
+          @remote_video_download
+        )
+        redirect_to(
+          gallery_remote_video_downloads_path(@gallery),
+          notice: "Video download queued"
+        )
+      else
+        render :new, status: :unprocessable_content
+      end
+    end
+
     private
 
     def find_gallery
       policy_scope(Gallery).find(params[:gallery_id])
+    end
+
+    def remote_video_download_params
+      params
+        .require(:remote_video_download)
+        .permit(:url)
     end
   end
 end

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -5,12 +5,9 @@ module Galleries
 
     def index
       @gallery = find_gallery
-      @remote_video_downloads = authorize(
-        @gallery.remote_video_downloads.new,
-        :index?
-      ).then do
+      authorize(@gallery.remote_video_downloads.new, :index?)
+      @remote_video_downloads =
         @gallery.remote_video_downloads.order(created_at: :desc)
-      end
     end
 
     def new

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -1,0 +1,19 @@
+module Galleries
+  class RemoteVideoDownloadsController < ApplicationController
+    before_action :ensure_authenticated!
+    after_action :verify_authorized
+
+    def new
+      @gallery = find_gallery
+      @remote_video_download = authorize(
+        @gallery.remote_video_downloads.new
+      )
+    end
+
+    private
+
+    def find_gallery
+      policy_scope(Gallery).find(params[:gallery_id])
+    end
+  end
+end

--- a/app/policies/galleries/remote_video_download_policy.rb
+++ b/app/policies/galleries/remote_video_download_policy.rb
@@ -1,0 +1,23 @@
+module Galleries
+  class RemoteVideoDownloadPolicy < ApplicationPolicy
+    def index?
+      user_owns_gallery?
+    end
+
+    def new?
+      user_owns_gallery?
+    end
+
+    def create?
+      user_owns_gallery?
+    end
+
+    private
+
+    def user_owns_gallery?
+      return false unless record.gallery
+
+      user && record.gallery.user == user
+    end
+  end
+end

--- a/app/views/galleries/remote_video_downloads/_form.html.erb
+++ b/app/views/galleries/remote_video_downloads/_form.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for(
+  @remote_video_download,
+  url: gallery_remote_video_downloads_path(@gallery)
+) do |form| %>
+  <%= form.input(:url, label: "Video URL") %>
+  <%= form.button(:submit, "Add video") %>
+<% end %>

--- a/app/views/galleries/remote_video_downloads/index.html.erb
+++ b/app/views/galleries/remote_video_downloads/index.html.erb
@@ -1,6 +1,7 @@
 <%= render(HeaderComponent.new(
   title: "Video downloads"
 )) do |c| %>
+  <%= c.with_crumb("Home", home_path) %>
   <%= c.with_crumb("Galleries", galleries_path) %>
   <%= c.with_crumb(@gallery.name, gallery_path(@gallery)) %>
 
@@ -13,7 +14,7 @@
   <% end %>
 <% end %>
 
-<% if @remote_video_downloads.any? %>
+<% if @remote_video_downloads.load.any? %>
   <table class="w-full text-left">
     <thead>
       <tr>
@@ -27,7 +28,13 @@
           <td class="py-1 pr-4 break-all">
             <%= download.url %>
           </td>
-          <td class="py-1"><%= download.status %></td>
+          <td class="py-1">
+            <%= render(
+              Galleries::RemoteVideoDownloadPillComponent.new(
+                remote_video_download: download
+              )
+            ) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/galleries/remote_video_downloads/index.html.erb
+++ b/app/views/galleries/remote_video_downloads/index.html.erb
@@ -1,0 +1,37 @@
+<%= render(HeaderComponent.new(
+  title: "Video downloads"
+)) do |c| %>
+  <%= c.with_crumb("Galleries", galleries_path) %>
+  <%= c.with_crumb(@gallery.name, gallery_path(@gallery)) %>
+
+  <%= c.with_action do %>
+    <%= link_to(
+      "Add video from URL",
+      new_gallery_remote_video_download_path(@gallery),
+      class: "button"
+    ) %>
+  <% end %>
+<% end %>
+
+<% if @remote_video_downloads.any? %>
+  <table class="w-full text-left">
+    <thead>
+      <tr>
+        <th class="pb-2">URL</th>
+        <th class="pb-2">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @remote_video_downloads.each do |download| %>
+        <tr>
+          <td class="py-1 pr-4 break-all">
+            <%= download.url %>
+          </td>
+          <td class="py-1"><%= download.status %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="text-gray-500">No video downloads yet.</p>
+<% end %>

--- a/app/views/galleries/remote_video_downloads/new.html.erb
+++ b/app/views/galleries/remote_video_downloads/new.html.erb
@@ -1,6 +1,7 @@
 <%= render(HeaderComponent.new(
   title: "Add video from URL"
 )) do |c| %>
+  <%= c.with_crumb("Home", home_path) %>
   <%= c.with_crumb("Galleries", galleries_path) %>
   <%= c.with_crumb(@gallery.name, gallery_path(@gallery)) %>
   <%= c.with_crumb(

--- a/app/views/galleries/remote_video_downloads/new.html.erb
+++ b/app/views/galleries/remote_video_downloads/new.html.erb
@@ -1,0 +1,12 @@
+<%= render(HeaderComponent.new(
+  title: "Add video from URL"
+)) do |c| %>
+  <%= c.with_crumb("Galleries", galleries_path) %>
+  <%= c.with_crumb(@gallery.name, gallery_path(@gallery)) %>
+  <%= c.with_crumb(
+    "Video downloads",
+    gallery_remote_video_downloads_path(@gallery)
+  ) %>
+<% end %>
+
+<%= render(partial: "form") %>

--- a/app/views/galleries/show.html.erb
+++ b/app/views/galleries/show.html.erb
@@ -22,6 +22,14 @@
 
       <%= c.with_action do %>
         <%= link_to(
+          "Add video from URL",
+          new_gallery_remote_video_download_path(@gallery),
+          class: "button"
+        ) %>
+      <% end %>
+
+      <%= c.with_action do %>
+        <%= link_to(
           "Tags",
           gallery_tags_path(@gallery),
           class: "button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
         resources :tags, only: %i[create destroy],
           controller: "bulk_uploads/tags"
       end
+      resources :remote_video_downloads, only: %i[index new create]
       resource :bulk_tag, only: %i[create]
       resource :bulk_delete, only: %i[create]
       resources :tags do

--- a/spec/components/galleries/remote_video_download_pill_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_pill_component_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Galleries::RemoteVideoDownloadPillComponent,
+  type: :component do
+  it "renders a gray pill for pending status" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "pending"
+    )
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "span.bg-gray-100.text-gray-800",
+      text: "pending"
+    )
+  end
+
+  it "renders a blue pill for downloading status" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "downloading"
+    )
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "span.bg-blue-100.text-blue-800",
+      text: "downloading"
+    )
+  end
+
+  it "renders a green pill for completed status" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "completed"
+    )
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "span.bg-green-100.text-green-800",
+      text: "completed"
+    )
+  end
+
+  it "renders a red pill for failed status" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "failed"
+    )
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "span.bg-red-100.text-red-800",
+      text: "failed"
+    )
+  end
+end

--- a/spec/policies/galleries/remote_video_download_policy_spec.rb
+++ b/spec/policies/galleries/remote_video_download_policy_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Galleries::RemoteVideoDownloadPolicy do
+  permissions :index?, :new?, :create? do
+    it "grants access when user owns the gallery" do
+      user = build(:user)
+      gallery = build(:gallery, user:)
+      download = Galleries::RemoteVideoDownload.new(gallery:)
+
+      expect(described_class).to permit(user, download)
+    end
+
+    it "denies access when user does not own the gallery" do
+      user = build(:user)
+      other_user = build(:user)
+      gallery = build(:gallery, user: other_user)
+      download = Galleries::RemoteVideoDownload.new(gallery:)
+
+      expect(described_class).not_to permit(user, download)
+    end
+
+    it "denies access when user is nil" do
+      gallery = build(:gallery)
+      download = Galleries::RemoteVideoDownload.new(gallery:)
+
+      expect(described_class).not_to permit(nil, download)
+    end
+
+    it "denies access when gallery is nil" do
+      user = build(:user)
+      download = Galleries::RemoteVideoDownload.new(gallery: nil)
+
+      expect(described_class).not_to permit(user, download)
+    end
+  end
+end

--- a/spec/policies/galleries/remote_video_download_policy_spec.rb
+++ b/spec/policies/galleries/remote_video_download_policy_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Galleries::RemoteVideoDownloadPolicy do
     it "grants access when user owns the gallery" do
       user = build(:user)
       gallery = build(:gallery, user:)
-      download = Galleries::RemoteVideoDownload.new(gallery:)
+      download = build(:galleries_remote_video_download, gallery:)
 
       expect(described_class).to permit(user, download)
     end
@@ -14,21 +14,21 @@ RSpec.describe Galleries::RemoteVideoDownloadPolicy do
       user = build(:user)
       other_user = build(:user)
       gallery = build(:gallery, user: other_user)
-      download = Galleries::RemoteVideoDownload.new(gallery:)
+      download = build(:galleries_remote_video_download, gallery:)
 
       expect(described_class).not_to permit(user, download)
     end
 
     it "denies access when user is nil" do
       gallery = build(:gallery)
-      download = Galleries::RemoteVideoDownload.new(gallery:)
+      download = build(:galleries_remote_video_download, gallery:)
 
       expect(described_class).not_to permit(nil, download)
     end
 
     it "denies access when gallery is nil" do
       user = build(:user)
-      download = Galleries::RemoteVideoDownload.new(gallery: nil)
+      download = build(:galleries_remote_video_download, gallery: nil)
 
       expect(described_class).not_to permit(user, download)
     end

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Galleries::RemoteVideoDownloadsController do
+  describe "new" do
+    it "requires authentication" do
+      gallery = create(:gallery)
+
+      get(new_gallery_remote_video_download_path(gallery))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when gallery is not owned by current user" do
+      gallery = create(:gallery)
+      other_user = create(:user)
+      login_as(other_user)
+
+      get(new_gallery_remote_video_download_path(gallery))
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renders the url form" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      login_as(user)
+
+      get(new_gallery_remote_video_download_path(gallery))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("remote_video_download[url]")
+    end
+  end
+end

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Galleries::RemoteVideoDownloadsController do
+  include ActiveJob::TestHelper
+
   describe "new" do
     it "requires authentication" do
       gallery = create(:gallery)
@@ -29,6 +31,69 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("remote_video_download[url]")
+    end
+  end
+
+  describe "create" do
+    it "creates a download and enqueues the job" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      login_as(user)
+      stub_const(
+        "Galleries::RemoteVideoDownloadJob",
+        Class.new(ApplicationJob)
+      )
+      params = {
+        remote_video_download: {url: "https://example.com/v.mp4"}
+      }
+
+      post(gallery_remote_video_downloads_path(gallery), params:)
+
+      expect(response).to redirect_to(
+        gallery_remote_video_downloads_path(gallery)
+      )
+      download = gallery.remote_video_downloads.last
+      expect(download.url).to eql("https://example.com/v.mp4")
+      expect(download).to be_status_pending
+      expect(Galleries::RemoteVideoDownloadJob)
+        .to have_been_enqueued.with(download)
+    end
+
+    it "rerenders the form when the url is blank" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      login_as(user)
+      params = {remote_video_download: {url: ""}}
+
+      post(gallery_remote_video_downloads_path(gallery), params:)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("remote_video_download[url]")
+      expect(gallery.remote_video_downloads.count).to eql(0)
+    end
+
+    it "requires authentication" do
+      gallery = create(:gallery)
+      params = {
+        remote_video_download: {url: "https://example.com/v.mp4"}
+      }
+
+      post(gallery_remote_video_downloads_path(gallery), params:)
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when gallery is not owned by current user" do
+      gallery = create(:gallery)
+      other_user = create(:user)
+      login_as(other_user)
+      params = {
+        remote_video_download: {url: "https://example.com/v.mp4"}
+      }
+
+      post(gallery_remote_video_downloads_path(gallery), params:)
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -34,6 +34,47 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
     end
   end
 
+  describe "index" do
+    it "lists the gallery's downloads with their status" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      create(
+        :galleries_remote_video_download,
+        gallery:,
+        url: "https://example.com/listed.mp4",
+        status: "downloading"
+      )
+      login_as(user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("https://example.com/listed.mp4")
+      expect(response.body).to include("downloading")
+      expect(response.body).to include(
+        new_gallery_remote_video_download_path(gallery)
+      )
+    end
+
+    it "requires authentication" do
+      gallery = create(:gallery)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when gallery is not owned by current user" do
+      gallery = create(:gallery)
+      other_user = create(:user)
+      login_as(other_user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "create" do
     it "creates a download and enqueues the job" do
       user = create(:user)

--- a/spec/requests/galleries_spec.rb
+++ b/spec/requests/galleries_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe GalleriesController do
       expect(page).to have_link("Galleries", href: galleries_path)
     end
 
+    it "links to the add-video-from-url form" do
+      gallery = create(:gallery)
+      login_as(gallery.user)
+
+      get(gallery_path(gallery))
+
+      expect(response.body).to include(
+        new_gallery_remote_video_download_path(gallery)
+      )
+      expect(response.body).to include("Add video from URL")
+    end
+
     it "includes a count of the number of images" do
       user = create(:user)
       gallery = create(:gallery, user:)


### PR DESCRIPTION
Adds a per-gallery "Submit UI" for remote video downloads, mirroring the existing `bulk_upload` quartet (route + controller + policy + views + request specs).

## Changes
- **Policy** — `Galleries::RemoteVideoDownloadPolicy` (`index?`/`new?`/`create?` gated on gallery ownership).
- **Route** — `resources :remote_video_downloads, only: %i[index new create]` nested under gallery.
- **Controller** — `Galleries::RemoteVideoDownloadsController`:
  - `#new` builds + authorizes a download.
  - `#create` saves it (status `pending`), enqueues `Galleries::RemoteVideoDownloadJob`, redirects to the index; blank url re-renders `:new` with `:unprocessable_content`.
  - `#index` lists the gallery's downloads (url + status, newest first).
- **Views** — `new` + `_form` (single URL field) and a read-only `index` table.
- **Gallery show** — an "Add video from URL" button.

## Notes
- `Galleries::RemoteVideoDownloadJob` belongs to a separate card; the create happy-path spec stubs it via `stub_const` so this PR stays independently green.
- Non-goals (deliberate): no retry route/action, no duplicate-URL prevention.

## Verification
- Affected suite: 37 examples, 0 failures.
- `bin/standardrb`: clean.