### PR TITLE
Index UI: per-gallery remote video download rows

### DIFF
--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -25,7 +25,7 @@ module Galleries
             @remote_video_download.url,
             target: "_blank",
             rel: "noopener",
-            class: "break-all text-blue-600 hover:underline"
+            class: "break-all text-blue-600 hover:text-blue-800"
           ) %>
           <%= render(Galleries::RemoteVideoDownloadPillComponent.new(
             remote_video_download: @remote_video_download

--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -1,0 +1,58 @@
+module Galleries
+  class RemoteVideoDownloadRowComponent < ApplicationComponent
+    erb_template <<~ERB
+      <div class="flex gap-4 py-3" data-role="rvd-row">
+        <div class="w-[200px] shrink-0">
+          <% if completed_with_image? %>
+            <%= render(Galleries::ImageThumbnailComponent.new(
+              image: @remote_video_download.image
+            )) %>
+          <% else %>
+            <div
+              class="flex items-center justify-center w-full
+                     h-[120px] bg-gray-100 rounded text-gray-400
+                     text-sm"
+              data-role="thumbnail-placeholder"
+            >
+              No video
+            </div>
+          <% end %>
+        </div>
+
+        <div class="flex flex-col items-start gap-1 min-w-0">
+          <%= link_to(
+            @remote_video_download.url,
+            @remote_video_download.url,
+            target: "_blank",
+            rel: "noopener",
+            class: "break-all text-blue-600 hover:underline"
+          ) %>
+          <%= render(Galleries::RemoteVideoDownloadPillComponent.new(
+            remote_video_download: @remote_video_download
+          )) %>
+          <% if failed_with_message? %>
+            <p class="text-red-600 text-sm" data-role="error-message">
+              <%= @remote_video_download.error_message %>
+            </p>
+          <% end %>
+        </div>
+      </div>
+    ERB
+
+    def initialize(remote_video_download:)
+      @remote_video_download = remote_video_download
+    end
+
+    private
+
+    def completed_with_image?
+      @remote_video_download.status_completed? &&
+        @remote_video_download.image.present?
+    end
+
+    def failed_with_message?
+      @remote_video_download.status_failed? &&
+        @remote_video_download.error_message.present?
+    end
+  end
+end

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -7,7 +7,9 @@ module Galleries
       @gallery = find_gallery
       authorize(@gallery.remote_video_downloads.new, :index?)
       @remote_video_downloads =
-        @gallery.remote_video_downloads.order(created_at: :desc)
+        @gallery.remote_video_downloads
+          .includes(image: [:gallery, {file_attachment: :blob}])
+          .order(created_at: :desc)
     end
 
     def new

--- a/app/views/galleries/remote_video_downloads/index.html.erb
+++ b/app/views/galleries/remote_video_downloads/index.html.erb
@@ -15,30 +15,15 @@
 <% end %>
 
 <% if @remote_video_downloads.load.any? %>
-  <table class="w-full text-left">
-    <thead>
-      <tr>
-        <th class="pb-2">URL</th>
-        <th class="pb-2">Status</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @remote_video_downloads.each do |download| %>
-        <tr>
-          <td class="py-1 pr-4 break-all">
-            <%= download.url %>
-          </td>
-          <td class="py-1">
-            <%= render(
-              Galleries::RemoteVideoDownloadPillComponent.new(
-                remote_video_download: download
-              )
-            ) %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="divide-y">
+    <% @remote_video_downloads.each do |download| %>
+      <%= render(
+        Galleries::RemoteVideoDownloadRowComponent.new(
+          remote_video_download: download
+        )
+      ) %>
+    <% end %>
+  </div>
 <% else %>
   <p class="text-gray-500">No video downloads yet.</p>
 <% end %>

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
+  type: :component do
+  it "renders the source url as an external link" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "pending",
+      url: "https://example.com/clip.mp4"
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "a[href='https://example.com/clip.mp4'][target='_blank']",
+      text: "https://example.com/clip.mp4"
+    )
+  end
+
+  it "renders the status pill" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "downloading"
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css("span.bg-blue-100", text: "downloading")
+  end
+
+  it "shows a placeholder when not completed" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      status: "pending"
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css("[data-role=thumbnail-placeholder]")
+    expect(page).to have_no_css("img")
+  end
+
+  it "links to the resulting image when completed" do
+    download = create(:galleries_remote_video_download, :completed)
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css("a[data-role=image-thumbnail]")
+    expect(page).to have_css("img")
+    expect(page).to have_no_css("[data-role=thumbnail-placeholder]")
+  end
+
+  it "shows the error message when failed" do
+    download = build_stubbed(
+      :galleries_remote_video_download,
+      :failed
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "[data-role=error-message]",
+      text: "unable to download video"
+    )
+  end
+end

--- a/spec/factories/galleries/remote_video_downloads.rb
+++ b/spec/factories/galleries/remote_video_downloads.rb
@@ -4,5 +4,15 @@ FactoryBot.define do
     gallery
     sequence(:url) { "https://example.com/video/#{it}.mp4" }
     status { "pending" }
+
+    trait :completed do
+      status { "completed" }
+      image { association(:galleries_image, gallery:) }
+    end
+
+    trait :failed do
+      status { "failed" }
+      error_message { "unable to download video" }
+    end
   end
 end

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -56,6 +56,38 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
       )
     end
 
+    it "links to the resulting image for a completed download" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(
+        :galleries_remote_video_download,
+        :completed,
+        gallery:
+      )
+      login_as(user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response.body).to include(
+        gallery_image_path(gallery, download.image)
+      )
+    end
+
+    it "shows the error message for a failed download" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      create(
+        :galleries_remote_video_download,
+        :failed,
+        gallery:
+      )
+      login_as(user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response.body).to include("unable to download video")
+    end
+
     it "requires authentication" do
       gallery = create(:gallery)
 

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -88,6 +88,22 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
       expect(response.body).to include("unable to download video")
     end
 
+    it "avoids N+1 queries with multiple completed downloads", :bullet do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      create_list(
+        :galleries_remote_video_download,
+        2,
+        :completed,
+        gallery:
+      )
+      login_as(user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response).to have_http_status(:ok)
+    end
+
     it "requires authentication" do
       gallery = create(:gallery)
 


### PR DESCRIPTION
Implements ticket 5 of the Video downloader feature: a richer per-gallery index UI for remote video downloads.

## What changed
- Add `Galleries::RemoteVideoDownloadRowComponent` rendering each download as a flex card: a thumbnail slot on the left and the source URL (external link), status badge, and error message stacked on the right.
  - **Completed** → reuses `Galleries::ImageThumbnailComponent` (links to `gallery_image_path`, renders the video poster with a play overlay).
  - **Failed** → shows `error_message` in red.
  - **Pending / downloading** → neutral "No video" placeholder so rows stay aligned.
  - Status badge reuses the existing `RemoteVideoDownloadPillComponent`.
- Replace the bare 2-column table in `index.html.erb` with a `divide-y` list of row components.
- Add `:completed` and `:failed` factory traits.
- Component spec covers every state; extend the existing index request spec to assert the completed-row image link and failed-row error message.

Read-only UI over the model — controller, route, policy, and job are unchanged. Live status updates (Turbo/polling) are intentionally out of scope.

## Tests
- `bin/rspec spec/components/galleries/remote_video_download_row_component_spec.rb` — 5 examples, 0 failures
- `bin/rspec spec/requests/galleries/remote_video_downloads_controller_spec.rb` — 12 examples, 0 failures