### PR TITLE
Retry + live updates for remote video downloads

### DIFF
--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -65,8 +65,7 @@ module Galleries
     end
 
     def failed_with_message?
-      @remote_video_download.status_failed? &&
-        @remote_video_download.error_message.present?
+      failed? && @remote_video_download.error_message.present?
     end
 
     def failed?

--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -1,7 +1,11 @@
 module Galleries
   class RemoteVideoDownloadRowComponent < ApplicationComponent
     erb_template <<~ERB
-      <div class="flex gap-4 py-3" data-role="rvd-row">
+      <div
+        id="remote_video_download_<%= @remote_video_download.id %>"
+        class="flex gap-4 py-3"
+        data-role="rvd-row"
+      >
         <div class="w-[200px] shrink-0">
           <% if completed_with_image? %>
             <%= render(Galleries::ImageThumbnailComponent.new(

--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -39,6 +39,16 @@ module Galleries
               <%= @remote_video_download.error_message %>
             </p>
           <% end %>
+          <% if failed? %>
+            <%= button_to(
+              "Retry",
+              gallery_remote_video_download_retries_path(
+                @remote_video_download.gallery,
+                @remote_video_download
+              ),
+              class: "button"
+            ) %>
+          <% end %>
         </div>
       </div>
     ERB
@@ -57,6 +67,10 @@ module Galleries
     def failed_with_message?
       @remote_video_download.status_failed? &&
         @remote_video_download.error_message.present?
+    end
+
+    def failed?
+      @remote_video_download.status_failed?
     end
   end
 end

--- a/app/controllers/galleries/remote_video_downloads/retries_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads/retries_controller.rb
@@ -1,0 +1,39 @@
+module Galleries
+  module RemoteVideoDownloads
+    class RetriesController < ApplicationController
+      before_action :ensure_authenticated!
+      after_action :verify_authorized
+
+      def create
+        @gallery = policy_scope(Gallery).find(params[:gallery_id])
+        @remote_video_download = authorize(
+          @gallery.remote_video_downloads.find(
+            params[:remote_video_download_id]
+          ),
+          :update?
+        )
+
+        unless @remote_video_download.status_failed?
+          return redirect_to(
+            gallery_remote_video_downloads_path(@gallery),
+            notice: "Only failed downloads can be retried"
+          )
+        end
+
+        @remote_video_download.update!(
+          status: :pending,
+          error_message: nil
+        )
+        @remote_video_download.broadcast_row
+        Galleries::RemoteVideoDownloadJob.perform_later(
+          @remote_video_download
+        )
+
+        redirect_to(
+          gallery_remote_video_downloads_path(@gallery),
+          notice: "Retry queued"
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/galleries/remote_video_download_job.rb
+++ b/app/jobs/galleries/remote_video_download_job.rb
@@ -22,8 +22,10 @@ module Galleries
     attr_reader :rvd
 
     def start_download
+      cleanup_stale_entry
       metube.add(url: rvd.url, prefix:)
       rvd.status_downloading!
+      rvd.broadcast_row
       reenqueue
     end
 
@@ -68,6 +70,7 @@ module Galleries
           rvd.update!(status: :completed, image:)
           image
         end
+      rvd.broadcast_row
       Galleries::ImageProcessingJob.perform_later(image)
       cleanup(entry)
     end
@@ -85,8 +88,17 @@ module Galleries
       self.class.set(wait: POLL_INTERVAL).perform_later(rvd)
     end
 
+    def cleanup_stale_entry
+      metube.delete_by_prefix(prefix)
+    rescue => e
+      Rails.logger.warn(
+        "RemoteVideoDownload #{rvd.id} stale cleanup failed: #{e.message}"
+      )
+    end
+
     def fail!(message)
       rvd.update!(status: :failed, error_message: message)
+      rvd.broadcast_row
     end
 
     def prefix = "rvd-#{rvd.id}"

--- a/app/models/galleries/remote_video_download.rb
+++ b/app/models/galleries/remote_video_download.rb
@@ -16,5 +16,18 @@ module Galleries
       prefix: true
 
     validates :url, presence: true
+
+    def broadcast_row
+      Turbo::StreamsChannel.broadcast_replace_to(
+        gallery.remote_video_downloads_stream_name,
+        target: "remote_video_download_#{id}",
+        partial: "galleries/remote_video_downloads/row",
+        locals: {remote_video_download: self}
+      )
+    rescue => e
+      Rails.logger.warn(
+        "RemoteVideoDownload #{id} broadcast failed: #{e.message}"
+      )
+    end
   end
 end

--- a/app/models/galleries/video_downloader/metube.rb
+++ b/app/models/galleries/video_downloader/metube.rb
@@ -29,6 +29,7 @@ module Galleries
         %w[queue done].each do |where|
           hist.fetch(where, []).each do |entry|
             next unless entry["custom_name_prefix"] == prefix
+            next unless entry["url"]
             delete(entry["url"], where:)
           end
         end

--- a/app/models/galleries/video_downloader/metube.rb
+++ b/app/models/galleries/video_downloader/metube.rb
@@ -20,8 +20,18 @@ module Galleries
         raw.get("/download/#{ERB::Util.url_encode(file)}").body
       end
 
-      def delete(id)
-        json.post("/delete", {ids: [id], where: "done"}).body
+      def delete(id, where: "done")
+        json.post("/delete", {ids: [id], where:}).body
+      end
+
+      def delete_by_prefix(prefix)
+        hist = history
+        %w[queue done].each do |where|
+          hist.fetch(where, []).each do |entry|
+            next unless entry["custom_name_prefix"] == prefix
+            delete(entry["url"], where:)
+          end
+        end
       end
 
       private

--- a/app/models/gallery.rb
+++ b/app/models/gallery.rb
@@ -46,6 +46,10 @@ class Gallery < ActiveRecord::Base
     "gallery_#{id}_processing_images"
   end
 
+  def remote_video_downloads_stream_name
+    "gallery_#{id}_remote_video_downloads"
+  end
+
   def recently_used_tags(excluded_image_ids: nil, image_limit: 10)
     Galleries::RecentTagsQuery.call(
       gallery: self,

--- a/app/policies/galleries/remote_video_download_policy.rb
+++ b/app/policies/galleries/remote_video_download_policy.rb
@@ -12,6 +12,10 @@ module Galleries
       user_owns_gallery?
     end
 
+    def update?
+      user_owns_gallery?
+    end
+
     private
 
     def user_owns_gallery?

--- a/app/views/galleries/remote_video_downloads/_row.html.erb
+++ b/app/views/galleries/remote_video_downloads/_row.html.erb
@@ -1,0 +1,3 @@
+<%= render(Galleries::RemoteVideoDownloadRowComponent.new(
+  remote_video_download:
+)) %>

--- a/app/views/galleries/remote_video_downloads/index.html.erb
+++ b/app/views/galleries/remote_video_downloads/index.html.erb
@@ -1,3 +1,7 @@
+<%= turbo_stream_from(
+  @gallery.remote_video_downloads_stream_name
+) %>
+
 <%= render(HeaderComponent.new(
   title: "Video downloads"
 )) do |c| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,9 @@ Rails.application.routes.draw do
         resources :tags, only: %i[create destroy],
           controller: "bulk_uploads/tags"
       end
-      resources :remote_video_downloads, only: %i[index new create]
+      resources :remote_video_downloads, only: %i[index new create] do
+        resource :retries, only: :create, module: :remote_video_downloads
+      end
       resource :bulk_tag, only: %i[create]
       resource :bulk_delete, only: %i[create]
       resources :tags do

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
   end
 
   it "renders a retry button when failed" do
-    download = create(:galleries_remote_video_download, :failed)
+    download = build_stubbed(:galleries_remote_video_download, :failed)
 
     render_inline(described_class.new(remote_video_download: download))
 

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
     )
   end
 
+  it "gives the row a stable dom id" do
+    download = build_stubbed(:galleries_remote_video_download)
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "#remote_video_download_#{download.id}"
+    )
+  end
+
   it "renders the status pill" do
     download = build_stubbed(
       :galleries_remote_video_download,

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
     expect(page).to have_no_css("[data-role=thumbnail-placeholder]")
   end
 
+  it "renders a retry button when failed" do
+    download = create(:galleries_remote_video_download, :failed)
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "form[action='" \
+      "#{gallery_remote_video_download_retries_path(
+        download.gallery, download
+      )}'] button",
+      text: "Retry"
+    )
+  end
+
+  it "renders no retry button when not failed" do
+    download = build_stubbed(
+      :galleries_remote_video_download, status: "downloading"
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_no_button("Retry")
+  end
+
   it "shows the error message when failed" do
     download = build_stubbed(
       :galleries_remote_video_download,

--- a/spec/jobs/galleries/remote_video_download_job_spec.rb
+++ b/spec/jobs/galleries/remote_video_download_job_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Galleries::RemoteVideoDownloadJob, "#perform" do
 
   it "starts the download and transitions to downloading" do
     metube = stub_metube
+    allow(metube).to receive(:delete_by_prefix)
     allow(metube).to receive(:add)
     rvd = create(:galleries_remote_video_download, status: "pending")
 
@@ -22,6 +23,7 @@ RSpec.describe Galleries::RemoteVideoDownloadJob, "#perform" do
 
   it "re-enqueues itself to poll" do
     metube = stub_metube
+    allow(metube).to receive(:delete_by_prefix)
     allow(metube).to receive(:add)
     rvd = create(:galleries_remote_video_download, status: "pending")
 
@@ -164,6 +166,7 @@ RSpec.describe Galleries::RemoteVideoDownloadJob, "#perform" do
 
   it "fails fast if add is unreachable" do
     metube = stub_metube
+    allow(metube).to receive(:delete_by_prefix)
     rvd = create(:galleries_remote_video_download, status: "pending")
     allow(metube).to receive(:add)
       .and_raise(Faraday::ConnectionFailed.new("down"))
@@ -173,6 +176,60 @@ RSpec.describe Galleries::RemoteVideoDownloadJob, "#perform" do
     rvd.reload
     expect(rvd).to be_status_failed
     expect(rvd.error_message).to eq("down")
+  end
+
+  it "clears any stale MeTube entry before re-adding" do
+    metube = stub_metube
+    allow(metube).to receive(:delete_by_prefix)
+    allow(metube).to receive(:add)
+    rvd = create(:galleries_remote_video_download, status: "pending")
+
+    described_class.new.perform(rvd)
+
+    expect(metube).to have_received(:delete_by_prefix)
+      .with("rvd-#{rvd.id}")
+  end
+
+  it "broadcasts the row when the download starts" do
+    metube = stub_metube
+    allow(metube).to receive(:delete_by_prefix)
+    allow(metube).to receive(:add)
+    rvd = create(:galleries_remote_video_download, status: "pending")
+    allow(rvd).to receive(:broadcast_row)
+
+    described_class.new.perform(rvd)
+
+    expect(rvd).to have_received(:broadcast_row)
+  end
+
+  it "broadcasts the row when the download completes" do
+    metube = stub_metube
+    rvd = create(:galleries_remote_video_download, status: "downloading")
+    entry = {
+      "custom_name_prefix" => "rvd-#{rvd.id}",
+      "status" => "finished", "filename" => "clip.mp4", "id" => "id-1"
+    }
+    allow(metube).to receive(:history)
+      .and_return("done" => [entry], "queue" => [], "pending" => [])
+    allow(metube).to receive(:fetch_file).and_return("videobytes")
+    allow(metube).to receive(:delete)
+    allow(rvd).to receive(:broadcast_row)
+
+    described_class.new.perform(rvd)
+
+    expect(rvd).to have_received(:broadcast_row)
+  end
+
+  it "broadcasts the row when the download fails" do
+    metube = stub_metube
+    rvd = create(:galleries_remote_video_download, status: "downloading")
+    allow(metube).to receive(:history)
+      .and_raise(Faraday::ConnectionFailed.new("down"))
+    allow(rvd).to receive(:broadcast_row)
+
+    described_class.new.perform(rvd)
+
+    expect(rvd).to have_received(:broadcast_row)
   end
 
   it "fails fast if history is unreachable" do

--- a/spec/models/galleries/remote_video_download_spec.rb
+++ b/spec/models/galleries/remote_video_download_spec.rb
@@ -21,4 +21,28 @@ RSpec.describe Galleries::RemoteVideoDownload do
   it "has a valid factory" do
     expect(build(:galleries_remote_video_download)).to be_valid
   end
+
+  it "broadcasts a replace of its row to the gallery stream" do
+    rvd = build_stubbed(:galleries_remote_video_download)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+
+    rvd.broadcast_row
+
+    expect(Turbo::StreamsChannel)
+      .to have_received(:broadcast_replace_to)
+      .with(
+        rvd.gallery.remote_video_downloads_stream_name,
+        target: "remote_video_download_#{rvd.id}",
+        partial: "galleries/remote_video_downloads/row",
+        locals: {remote_video_download: rvd}
+      )
+  end
+
+  it "swallows broadcast errors so callers are unaffected" do
+    rvd = build_stubbed(:galleries_remote_video_download)
+    allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
+      .and_raise(StandardError.new("boom"))
+
+    expect { rvd.broadcast_row }.not_to raise_error
+  end
 end

--- a/spec/models/galleries/video_downloader/metube_spec.rb
+++ b/spec/models/galleries/video_downloader/metube_spec.rb
@@ -84,6 +84,44 @@ RSpec.describe Galleries::VideoDownloader::Metube do
     end
   end
 
+  describe "#delete_by_prefix" do
+    it "deletes matching queue and done entries" do
+      history = {
+        "queue" => [
+          {"custom_name_prefix" => "rvd-1", "url" => "u-q"},
+          {"custom_name_prefix" => "rvd-2", "url" => "u-x"}
+        ],
+        "done" => [
+          {"custom_name_prefix" => "rvd-1", "url" => "u-d"}
+        ]
+      }
+      FakeMetube.stub(method: :get, path: "/history").to_return(
+        body: history.to_json,
+        headers: {"content-type" => "application/json"},
+        status: 200
+      )
+      queue_delete = FakeMetube.stub(method: :post, path: "/delete")
+        .with(body: {ids: ["u-q"], where: "queue"})
+        .to_return(
+          body: "{}",
+          headers: {"content-type" => "application/json"},
+          status: 200
+        )
+      done_delete = FakeMetube.stub(method: :post, path: "/delete")
+        .with(body: {ids: ["u-d"], where: "done"})
+        .to_return(
+          body: "{}",
+          headers: {"content-type" => "application/json"},
+          status: 200
+        )
+
+      described_class.new.delete_by_prefix("rvd-1")
+
+      expect(queue_delete).to have_been_requested
+      expect(done_delete).to have_been_requested
+    end
+  end
+
   describe "#fetch_file" do
     it "returns the raw bytes for the requested file" do
       bytes = "\x00\x01video".b

--- a/spec/models/gallery_spec.rb
+++ b/spec/models/gallery_spec.rb
@@ -68,6 +68,13 @@ RSpec.describe Gallery do
     end
   end
 
+  it "names the remote video downloads turbo stream" do
+    gallery = build_stubbed(:gallery)
+
+    expect(gallery.remote_video_downloads_stream_name)
+      .to eql("gallery_#{gallery.id}_remote_video_downloads")
+  end
+
   describe "#recently_used_tags" do
     it "calls the query object" do
       allow(Galleries::RecentTagsQuery).to receive(:call)

--- a/spec/policies/galleries/remote_video_download_policy_spec.rb
+++ b/spec/policies/galleries/remote_video_download_policy_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Galleries::RemoteVideoDownloadPolicy do
+  permissions :update? do
+    it "grants access when user owns the gallery" do
+      user = build(:user)
+      gallery = build(:gallery, user:)
+      download = build(:galleries_remote_video_download, gallery:)
+
+      expect(described_class).to permit(user, download)
+    end
+
+    it "denies access when user does not own the gallery" do
+      user = build(:user)
+      gallery = build(:gallery, user: build(:user))
+      download = build(:galleries_remote_video_download, gallery:)
+
+      expect(described_class).not_to permit(user, download)
+    end
+  end
+
   permissions :index?, :new?, :create? do
     it "grants access when user owns the gallery" do
       user = build(:user)

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -133,6 +133,78 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
     end
   end
 
+  describe "retry" do
+    it "resets a failed download and re-enqueues the job" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(
+        :galleries_remote_video_download, :failed, gallery:
+      )
+      login_as(user)
+      stub_const(
+        "Galleries::RemoteVideoDownloadJob",
+        Class.new(ApplicationJob)
+      )
+
+      post(gallery_remote_video_download_retries_path(gallery, download))
+
+      expect(response).to redirect_to(
+        gallery_remote_video_downloads_path(gallery)
+      )
+      download.reload
+      expect(download).to be_status_pending
+      expect(download.error_message).to be_nil
+      expect(Galleries::RemoteVideoDownloadJob)
+        .to have_been_enqueued.with(download)
+    end
+
+    it "does not re-enqueue a download that has not failed" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(
+        :galleries_remote_video_download,
+        gallery:, status: "downloading"
+      )
+      login_as(user)
+      stub_const(
+        "Galleries::RemoteVideoDownloadJob",
+        Class.new(ApplicationJob)
+      )
+
+      post(gallery_remote_video_download_retries_path(gallery, download))
+
+      expect(response).to redirect_to(
+        gallery_remote_video_downloads_path(gallery)
+      )
+      expect(download.reload).to be_status_downloading
+      expect(Galleries::RemoteVideoDownloadJob)
+        .not_to have_been_enqueued
+    end
+
+    it "requires authentication" do
+      gallery = create(:gallery)
+      download = create(
+        :galleries_remote_video_download, :failed, gallery:
+      )
+
+      post(gallery_remote_video_download_retries_path(gallery, download))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when gallery is not owned by current user" do
+      gallery = create(:gallery)
+      download = create(
+        :galleries_remote_video_download, :failed, gallery:
+      )
+      login_as(create(:user))
+
+      post(gallery_remote_video_download_retries_path(gallery, download))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "create" do
     it "creates a download and enqueues the job" do
       user = create(:user)

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
       )
     end
 
+    it "subscribes to the live updates stream" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      login_as(user)
+
+      get(gallery_remote_video_downloads_path(gallery))
+
+      expect(response.body).to include("turbo-cable-stream-source")
+    end
+
     it "links to the resulting image for a completed download" do
       user = create(:user)
       gallery = create(:gallery, user:)


### PR DESCRIPTION
Implements ticket **6. Retry + live updates (polish)** — two independent polish features layered on the existing submit → download → import → cleanup → view loop.

## A. Retry
- Nested `resource :retries` create action resets a **failed** `Galleries::RemoteVideoDownload` to `pending` (clears `error_message`) and re-enqueues `RemoteVideoDownloadJob`, reusing its `start_download` branch.
- Policy `update?` delegates to `user_owns_gallery?`; controller authorizes against `:update?`.
- Guarded: non-failed downloads redirect back with a notice (no-op).
- **Retry** button renders only on failed rows.
- On retry, the job clears any stale MeTube entry (`delete_by_prefix`, scans both `queue` and `done`) before re-adding, avoiding prefix collisions.

## B. Live updates
- Per-gallery Turbo Stream `gallery_<id>_remote_video_downloads`; the index subscribes via `turbo_stream_from`.
- Each status transition (`start_download` → downloading, `handle_finished` → completed, `fail!` → failed, retry → pending) broadcasts a replace of the row.
- Broadcasting is **best-effort** — `broadcast_row` rescues/logs, so a render/host error never flips a real status. Rows replace through a thin `_row` partial wrapping the existing ViewComponent.
- Broadcasts only (no ActionCable channel / polling reconcile); a missed frame leaves a stale row until reload (accepted for polish).

## Testing
Model, policy, request, component, metube, and job specs added/updated. Full suite: 1183 examples, 0 failures. `standardrb` clean.