### PR TITLE
Add unique [gallery_id, url] index on remote_video_downloads

### DIFF
--- a/app/models/galleries/remote_video_download.rb
+++ b/app/models/galleries/remote_video_download.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: galleries_remote_video_downloads
+# Database name: primary
+#
+#  id            :bigint           not null, primary key
+#  error_message :text
+#  status        :enum             default("pending"), not null
+#  url           :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  gallery_id    :bigint           not null
+#  image_id      :bigint
+#
+# Indexes
+#
+#  index_galleries_remote_video_downloads_on_gallery_id  (gallery_id)
+#  index_galleries_remote_video_downloads_on_image_id    (image_id)
+#  index_galleries_rvd_on_gallery_id_and_url             (gallery_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (gallery_id => galleries.id)
+#  fk_rails_...  (image_id => galleries_images.id) ON DELETE => nullify
+#
 module Galleries
   class RemoteVideoDownload < ApplicationRecord
     belongs_to :gallery
@@ -15,7 +40,9 @@ module Galleries
       validate: true,
       prefix: true
 
-    validates :url, presence: true
+    validates :url,
+      presence: true,
+      uniqueness: {scope: :gallery_id}
 
     def broadcast_row
       Turbo::StreamsChannel.broadcast_replace_to(

--- a/db/migrate/20260627201209_add_unique_index_to_galleries_remote_video_downloads.rb
+++ b/db/migrate/20260627201209_add_unique_index_to_galleries_remote_video_downloads.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToGalleriesRemoteVideoDownloads <
+  ActiveRecord::Migration[8.1]
+  def change
+    add_index(
+      :galleries_remote_video_downloads,
+      [:gallery_id, :url],
+      unique: true,
+      name: "index_galleries_rvd_on_gallery_id_and_url"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_27_170754) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_27_201209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "vector"
@@ -138,6 +138,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_170754) do
     t.enum "status", default: "pending", null: false, enum_type: "galleries_remote_video_download_status"
     t.datetime "updated_at", null: false
     t.string "url", null: false
+    t.index ["gallery_id", "url"], name: "index_galleries_rvd_on_gallery_id_and_url", unique: true
     t.index ["gallery_id"], name: "index_galleries_remote_video_downloads_on_gallery_id"
     t.index ["image_id"], name: "index_galleries_remote_video_downloads_on_image_id"
   end

--- a/spec/factories/galleries/remote_video_downloads.rb
+++ b/spec/factories/galleries/remote_video_downloads.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: galleries_remote_video_downloads
+# Database name: primary
+#
+#  id            :bigint           not null, primary key
+#  error_message :text
+#  status        :enum             default("pending"), not null
+#  url           :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  gallery_id    :bigint           not null
+#  image_id      :bigint
+#
+# Indexes
+#
+#  index_galleries_remote_video_downloads_on_gallery_id  (gallery_id)
+#  index_galleries_remote_video_downloads_on_image_id    (image_id)
+#  index_galleries_rvd_on_gallery_id_and_url             (gallery_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (gallery_id => galleries.id)
+#  fk_rails_...  (image_id => galleries_images.id) ON DELETE => nullify
+#
 FactoryBot.define do
   factory :galleries_remote_video_download,
     class: "Galleries::RemoteVideoDownload" do

--- a/spec/models/galleries/remote_video_download_spec.rb
+++ b/spec/models/galleries/remote_video_download_spec.rb
@@ -1,10 +1,38 @@
 require "rails_helper"
 
+# == Schema Information
+#
+# Table name: galleries_remote_video_downloads
+# Database name: primary
+#
+#  id            :bigint           not null, primary key
+#  error_message :text
+#  status        :enum             default("pending"), not null
+#  url           :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  gallery_id    :bigint           not null
+#  image_id      :bigint
+#
+# Indexes
+#
+#  index_galleries_remote_video_downloads_on_gallery_id  (gallery_id)
+#  index_galleries_remote_video_downloads_on_image_id    (image_id)
+#  index_galleries_rvd_on_gallery_id_and_url             (gallery_id,url) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (gallery_id => galleries.id)
+#  fk_rails_...  (image_id => galleries_images.id) ON DELETE => nullify
+#
 RSpec.describe Galleries::RemoteVideoDownload do
+  subject { build(:galleries_remote_video_download) }
+
   it { is_expected.to belong_to(:gallery) }
   it { is_expected.to belong_to(:image).optional }
 
   it { is_expected.to validate_presence_of(:url) }
+  it { is_expected.to validate_uniqueness_of(:url).scoped_to(:gallery_id) }
 
   it {
     is_expected.to define_enum_for(:status)


### PR DESCRIPTION
## What

Adds a composite **unique** index on `[gallery_id, url]` for `galleries_remote_video_downloads`, plus a matching `uniqueness: {scope: :gallery_id}` validation on `Galleries::RemoteVideoDownload`.

## Why

`url` is `NOT NULL` but not unique (only `gallery_id` and `image_id` are indexed), so the same URL could be downloaded multiple times within one gallery. This enabled duplicate downloads and the shared-url cross-cancel edge in MeTube `delete_by_prefix` cleanup (two rows, same `url`, different `rvd-<id>` prefixes that MeTube's URL-keyed `/delete` can't distinguish).

Surfaced in the PR #831 review; intentionally deferred from that PR's scope.

## Notes

- The migration **does not dedupe** existing rows (per request). If duplicate `[gallery_id, url]` rows already exist in the target database, the unique index creation will fail and the migration must be run after manual cleanup.

## Testing

- `bin/rspec spec/models/galleries/remote_video_download_spec.rb` — 8 examples, 0 failures
- Related job/controller/component/policy specs — 52 examples, 0 failures
- standardrb clean
