### PR TITLE
Add API endpoint for adding remote video downloads

### DIFF
--- a/app/controllers/api/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/api/galleries/remote_video_downloads_controller.rb
@@ -1,0 +1,40 @@
+module Api
+  module Galleries
+    class RemoteVideoDownloadsController < BaseController
+      before_action :ensure_authenticated!
+      after_action :verify_authorized
+
+      def create
+        @gallery = find_gallery
+        @remote_video_download = authorize(
+          @gallery.remote_video_downloads.build(
+            remote_video_download_params
+          )
+        )
+
+        if @remote_video_download.save
+          ::Galleries::RemoteVideoDownloadJob.perform_later(
+            @remote_video_download
+          )
+          head :accepted
+        else
+          render json: {
+            errors: @remote_video_download.errors.full_messages
+          }, status: :bad_request
+        end
+      end
+
+      private
+
+      def find_gallery
+        policy_scope(Gallery).find(params[:gallery_id])
+      end
+
+      def remote_video_download_params
+        params
+          .require(:remote_video_download)
+          .permit(:url)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :galleries, only: [] do
       scope module: :galleries do
         resources :images, only: %w[create]
+        resources :remote_video_downloads, only: %w[create]
       end
     end
     scope module: :plants do

--- a/spec/requests/api/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/api/galleries/remote_video_downloads_controller_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Api::Galleries::RemoteVideoDownloadsController do
+  describe "create" do
+    it "creates a remote video download" do
+      gallery = create(:gallery)
+      login_as(gallery.user)
+      path = api_gallery_remote_video_downloads_path(gallery)
+
+      post(path, params: valid_params)
+
+      expect(response).to have_http_status(:accepted)
+      expect(response.body).to be_blank
+      rvd = gallery.remote_video_downloads.sole
+      expect(rvd.url).to eql("https://example.com/v.mp4")
+    end
+
+    it "enqueues RemoteVideoDownloadJob" do
+      gallery = create(:gallery)
+      login_as(gallery.user)
+      path = api_gallery_remote_video_downloads_path(gallery)
+      expect(Galleries::RemoteVideoDownloadJob)
+        .to receive(:perform_later)
+
+      post(path, params: valid_params)
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it "returns errors if invalid" do
+      gallery = create(:gallery)
+      login_as(gallery.user)
+      path = api_gallery_remote_video_downloads_path(gallery)
+      params = {remote_video_download: {url: ""}}
+
+      post(path, params:)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(json_response).to eql({
+        "errors" => ["Url can't be blank"]
+      })
+    end
+
+    it "returns 404 for a gallery not owned by the current user" do
+      gallery = create(:gallery)
+      login_as(create(:user))
+      path = api_gallery_remote_video_downloads_path(gallery)
+
+      post(path, params: valid_params)
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "requires authentication" do
+      gallery = create(:gallery)
+      path = api_gallery_remote_video_downloads_path(gallery)
+
+      post(path, params: valid_params)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  def valid_params
+    {remote_video_download: {url: "https://example.com/v.mp4"}}
+  end
+end


### PR DESCRIPTION
## Summary
Adds a JSON API `create` endpoint so an authenticated API client can POST a video URL to a gallery and have it queued for download.

- `POST /api/galleries/:gallery_id/remote_video_downloads`
- Thin `Api::Galleries::RemoteVideoDownloadsController < Api::BaseController` mirroring `Api::Galleries::ImagesController` and the HTML `Galleries::RemoteVideoDownloadsController#create`.
- Reuses the existing model, `Galleries::RemoteVideoDownloadPolicy`, and `Galleries::RemoteVideoDownloadJob` unchanged — no new business logic.
- Success returns an empty `202 Accepted`; invalid input returns `400` with `errors`.

## Auth outcomes
- No/invalid Bearer token → `401`.
- Valid token but gallery not owned by user → `404` (via `policy_scope`).

## Testing
Request spec covering: valid create (202, enqueues job), blank url (400 + errors), unowned gallery (404), unauthenticated (401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)