### PR TITLE
Defer psql readiness check until just before db:setup

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -14,11 +14,6 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
@@ -32,6 +27,14 @@ jobs:
         with:
           bundler-cache: true
       - run: echo -n "$TEST_KEY" > config/credentials/test.key
+      - name: Wait for PostgreSQL
+        run: |
+          for i in $(seq 1 30); do
+            pg_isready -h localhost -p 5432 && exit 0
+            sleep 1
+          done
+          echo "::error::PostgreSQL did not become ready within 30s"
+          exit 1
       - run: bin/rails db:setup assets:precompile
       - run: bundle exec annotaterb models
       - name: Verify db annotations are up to date

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -57,11 +57,6 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       RAILS_ENV: test
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
@@ -117,6 +112,14 @@ jobs:
           npx --yes playwright@${{ steps.playwright-version.outputs.version }} \
             install chromium
       - run: echo -n "$TEST_KEY" > config/credentials/test.key
+      - name: Wait for PostgreSQL
+        run: |
+          for i in $(seq 1 30); do
+            pg_isready -h localhost -p 5432 && exit 0
+            sleep 1
+          done
+          echo "::error::PostgreSQL did not become ready within 30s"
+          exit 1
       - run: bin/rails db:setup assets:precompile
       - run: bin/rspec spec/system
 


### PR DESCRIPTION
## What

Removes the `--health-*` options from the `postgres` service in the `unit_tests` and `system_tests` jobs, and adds an explicit `Wait for PostgreSQL` step (a bounded `pg_isready` loop) immediately before `bin/rails db:setup` in each.

## Why

With a health check configured on the service, GitHub Actions blocks on the auto-generated "Waiting for all services to be ready" step at the very start of the job — before checkout, gem install, and (for system tests) npm/Playwright install, none of which need the DB. By the time `db:setup` runs, psql has long since been up.

Deferring the readiness check to just before `db:setup` means postgres has had the whole setup phase to boot, so the wait almost always passes on the first attempt. The `pgvector/pgvector` image has no built-in `HEALTHCHECK`, so removing `options:` makes GitHub stop waiting at startup. The bounded 30s loop still fails loudly if psql never comes up.

## Scope

Only the two jobs that use psql. `lint`, `build_push`, and `deploy` are untouched.