### PR TITLE
Delete remote video download

### DIFF
--- a/app/components/galleries/remote_video_download_row_component.rb
+++ b/app/components/galleries/remote_video_download_row_component.rb
@@ -49,6 +49,16 @@ module Galleries
               class: "button"
             ) %>
           <% end %>
+          <%= button_to(
+            "Delete",
+            gallery_remote_video_download_path(
+              @remote_video_download.gallery,
+              @remote_video_download
+            ),
+            method: "delete",
+            data: {turbo_confirm: "Delete this video download?"},
+            class: "button button--danger"
+          ) %>
         </div>
       </div>
     ERB

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -64,7 +64,7 @@ module Galleries
 
     def cancel_metube_entry(remote_video_download)
       Galleries::VideoDownloader::Metube.new
-        .delete_by_prefix("rvd-#{remote_video_download.id}")
+        .delete_by_prefix(remote_video_download.metube_prefix)
     rescue => e
       Rails.logger.warn(
         "RemoteVideoDownload #{remote_video_download.id} " \

--- a/app/controllers/galleries/remote_video_downloads_controller.rb
+++ b/app/controllers/galleries/remote_video_downloads_controller.rb
@@ -40,10 +40,36 @@ module Galleries
       end
     end
 
+    def destroy
+      @gallery = find_gallery
+      @remote_video_download = authorize(
+        @gallery.remote_video_downloads.find(params[:id])
+      )
+
+      @remote_video_download.destroy!
+      cancel_metube_entry(@remote_video_download)
+
+      redirect_to(
+        gallery_remote_video_downloads_path(@gallery),
+        status: :see_other,
+        notice: "Video download was deleted."
+      )
+    end
+
     private
 
     def find_gallery
       policy_scope(Gallery).find(params[:gallery_id])
+    end
+
+    def cancel_metube_entry(remote_video_download)
+      Galleries::VideoDownloader::Metube.new
+        .delete_by_prefix("rvd-#{remote_video_download.id}")
+    rescue => e
+      Rails.logger.warn(
+        "RemoteVideoDownload #{remote_video_download.id} " \
+        "metube cleanup failed: #{e.message}"
+      )
     end
 
     def remote_video_download_params

--- a/app/jobs/galleries/remote_video_download_job.rb
+++ b/app/jobs/galleries/remote_video_download_job.rb
@@ -103,7 +103,7 @@ module Galleries
       rvd.broadcast_row
     end
 
-    def prefix = "rvd-#{rvd.id}"
+    def prefix = rvd.metube_prefix
 
     def metube = @metube ||= Galleries::VideoDownloader::Metube.new
   end

--- a/app/jobs/galleries/remote_video_download_job.rb
+++ b/app/jobs/galleries/remote_video_download_job.rb
@@ -2,6 +2,8 @@ module Galleries
   class RemoteVideoDownloadJob < ApplicationJob
     queue_as :background
 
+    discard_on ActiveJob::DeserializationError
+
     POLL_INTERVAL = 30.seconds
     MAX_DURATION = 1.hour
 

--- a/app/models/galleries/remote_video_download.rb
+++ b/app/models/galleries/remote_video_download.rb
@@ -44,6 +44,8 @@ module Galleries
       presence: true,
       uniqueness: {scope: :gallery_id}
 
+    def metube_prefix = "rvd-#{id}"
+
     def broadcast_row
       Turbo::StreamsChannel.broadcast_replace_to(
         gallery.remote_video_downloads_stream_name,

--- a/app/policies/galleries/remote_video_download_policy.rb
+++ b/app/policies/galleries/remote_video_download_policy.rb
@@ -16,6 +16,10 @@ module Galleries
       user_owns_gallery?
     end
 
+    def destroy?
+      user_owns_gallery?
+    end
+
     private
 
     def user_owns_gallery?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,8 @@ Rails.application.routes.draw do
         resources :tags, only: %i[create destroy],
           controller: "bulk_uploads/tags"
       end
-      resources :remote_video_downloads, only: %i[index new create] do
+      resources :remote_video_downloads,
+        only: %i[index new create destroy] do
         resource :retries, only: :create, module: :remote_video_downloads
       end
       resource :bulk_tag, only: %i[create]

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -84,6 +84,33 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
     expect(page).to have_no_button("Retry")
   end
 
+  it "renders a delete button for every status" do
+    download = build_stubbed(
+      :galleries_remote_video_download, status: "downloading"
+    )
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "form[action='" \
+      "#{gallery_remote_video_download_path(
+        download.gallery, download
+      )}'] button",
+      text: "Delete"
+    )
+  end
+
+  it "asks for confirmation before deleting" do
+    download = build_stubbed(:galleries_remote_video_download)
+
+    render_inline(described_class.new(remote_video_download: download))
+
+    expect(page).to have_css(
+      "button[data-turbo-confirm='Delete this video download?']",
+      text: "Delete"
+    )
+  end
+
   it "shows the error message when failed" do
     download = build_stubbed(
       :galleries_remote_video_download,

--- a/spec/components/galleries/remote_video_download_row_component_spec.rb
+++ b/spec/components/galleries/remote_video_download_row_component_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
     expect(page).to have_no_button("Retry")
   end
 
-  it "renders a delete button for every status" do
+  it "renders a delete button with a confirmation for every status" do
     download = build_stubbed(
       :galleries_remote_video_download, status: "downloading"
     )
@@ -95,18 +95,7 @@ RSpec.describe Galleries::RemoteVideoDownloadRowComponent,
       "form[action='" \
       "#{gallery_remote_video_download_path(
         download.gallery, download
-      )}'] button",
-      text: "Delete"
-    )
-  end
-
-  it "asks for confirmation before deleting" do
-    download = build_stubbed(:galleries_remote_video_download)
-
-    render_inline(described_class.new(remote_video_download: download))
-
-    expect(page).to have_css(
-      "button[data-turbo-confirm='Delete this video download?']",
+      )}'] button[data-turbo-confirm='Delete this video download?']",
       text: "Delete"
     )
   end

--- a/spec/jobs/galleries/remote_video_download_job_spec.rb
+++ b/spec/jobs/galleries/remote_video_download_job_spec.rb
@@ -1,6 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Galleries::RemoteVideoDownloadJob, "#perform" do
+  include ActiveJob::TestHelper
+
+  it "discards the poll job when the download was deleted" do
+    rvd = create(:galleries_remote_video_download, status: "downloading")
+    described_class.perform_later(rvd)
+    rvd.destroy!
+
+    expect { perform_enqueued_jobs }.not_to raise_error
+  end
+
   def stub_metube
     metube = instance_double(Galleries::VideoDownloader::Metube)
     allow(Galleries::VideoDownloader::Metube)

--- a/spec/policies/galleries/remote_video_download_policy_spec.rb
+++ b/spec/policies/galleries/remote_video_download_policy_spec.rb
@@ -1,6 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Galleries::RemoteVideoDownloadPolicy do
+  permissions :destroy? do
+    it "grants access when user owns the gallery" do
+      user = build(:user)
+      gallery = build(:gallery, user:)
+      download = build(:galleries_remote_video_download, gallery:)
+
+      expect(described_class).to permit(user, download)
+    end
+
+    it "denies access when user does not own the gallery" do
+      user = build(:user)
+      gallery = build(:gallery, user: build(:user))
+      download = build(:galleries_remote_video_download, gallery:)
+
+      expect(described_class).not_to permit(user, download)
+    end
+  end
+
   permissions :update? do
     it "grants access when user owns the gallery" do
       user = build(:user)

--- a/spec/requests/galleries/remote_video_downloads_controller_spec.rb
+++ b/spec/requests/galleries/remote_video_downloads_controller_spec.rb
@@ -205,6 +205,100 @@ RSpec.describe Galleries::RemoteVideoDownloadsController do
     end
   end
 
+  def stub_metube
+    metube = instance_double(Galleries::VideoDownloader::Metube)
+    allow(Galleries::VideoDownloader::Metube)
+      .to receive(:new).and_return(metube)
+    allow(metube).to receive(:delete_by_prefix)
+    metube
+  end
+
+  describe "destroy" do
+    it "deletes the download and redirects to the index" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(:galleries_remote_video_download, gallery:)
+      login_as(user)
+      stub_metube
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(response).to redirect_to(
+        gallery_remote_video_downloads_path(gallery)
+      )
+      expect(Galleries::RemoteVideoDownload.exists?(download.id))
+        .to be(false)
+    end
+
+    it "leaves the associated image in the gallery" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(
+        :galleries_remote_video_download, :completed, gallery:
+      )
+      image = download.image
+      login_as(user)
+      stub_metube
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(Galleries::Image.exists?(image.id)).to be(true)
+    end
+
+    it "cancels the in-flight MeTube entry" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(
+        :galleries_remote_video_download,
+        gallery:, status: "downloading"
+      )
+      login_as(user)
+      metube = stub_metube
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(metube).to have_received(:delete_by_prefix)
+        .with("rvd-#{download.id}")
+    end
+
+    it "still deletes when MeTube cleanup fails" do
+      user = create(:user)
+      gallery = create(:gallery, user:)
+      download = create(:galleries_remote_video_download, gallery:)
+      login_as(user)
+      metube = stub_metube
+      allow(metube).to receive(:delete_by_prefix)
+        .and_raise(Faraday::ConnectionFailed.new("down"))
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(response).to redirect_to(
+        gallery_remote_video_downloads_path(gallery)
+      )
+      expect(Galleries::RemoteVideoDownload.exists?(download.id))
+        .to be(false)
+    end
+
+    it "requires authentication" do
+      gallery = create(:gallery)
+      download = create(:galleries_remote_video_download, gallery:)
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 404 when gallery is not owned by current user" do
+      gallery = create(:gallery)
+      download = create(:galleries_remote_video_download, gallery:)
+      login_as(create(:user))
+
+      delete(gallery_remote_video_download_path(gallery, download))
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
   describe "create" do
     it "creates a download and enqueues the job" do
       user = create(:user)


### PR DESCRIPTION
## Summary
Adds a Delete button to each remote-video-download row on the gallery
index. Deleting destroys the `Galleries::RemoteVideoDownload` row only —
the associated gallery image is intentionally left in place (the
`image_id` FK nullifies on delete).

- Add `destroy?` to `Galleries::RemoteVideoDownloadPolicy` (owner-only).
- Add `DELETE` route + controller `destroy` action with best-effort,
  synchronous MeTube cancellation (`delete_by_prefix("rvd-<id>")`); a
  MeTube outage logs a warning but does not block the delete.
- Make `RemoteVideoDownloadJob` tolerate a vanished record via
  `discard_on ActiveJob::DeserializationError`, so an in-flight poll job
  is cleanly discarded after the row is deleted.
- Add a `button_to "Delete"` with a `turbo_confirm` dialog to the row
  ViewComponent, shown for every status. Plain redirect to the index
  with a flash notice (no Turbo broadcast on delete).

## Testing
- `mise exec -- bin/rspec` → 1199 examples, 0 failures
- `mise exec -- bin/standardrb` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)